### PR TITLE
Add bulk send ritual script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ We welcome pull requests! Here's how to help:
 4. Push to the branch (`git push origin feature/your-feature`)
 5. Open a pull request
 
+## 🕯️ Bulk Send Ritual
+
+Use our send-all ceremony to push every branch, tag, and outstanding change in one go when you are ready to sync the hive.
+
+```bash
+npm run send:all
+```
+
+The script will authenticate with GitHub CLI, fetch fresh refs, auto-commit a clean working tree, push branches and tags, open pull requests for branches diverging from `main`, and finish by labelling each PR for the roadmap.
+
 ## 🐝 Bee Philosophy
 
 BeeHive is built on the idea that creativity should be fast, collaborative, and sweet. Like bees, we work together to pollinate ideas and build something beautiful.

--- a/package.json
+++ b/package.json
@@ -1,1 +1,28 @@
-{"name":"adgenxai","version":"0.1.0","private":true,"scripts":{"dev":"next dev","build":"next build","start":"next start","lint":"next lint","export":"next export"},"dependencies":{"next":"^14.2.33","react":"^18","react-dom":"^18"},"devDependencies":{"@types/node":"^20.14.12","@types/react":"^18.3.12","autoprefixer":"^10.4.16","eslint":"^8","eslint-config-next":"14.2.3","postcss":"^8","tailwindcss":"^3.4.1","typescript":"^5.6.3"}}
+{
+  "name": "adgenxai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "export": "next export",
+    "send:all": "bash scripts/bulk-send.sh"
+  },
+  "dependencies": {
+    "next": "^14.2.33",
+    "react": "^18",
+    "react-dom": "^18"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@types/react": "^18.3.12",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.3",
+    "postcss": "^8",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/scripts/bulk-send.sh
+++ b/scripts/bulk-send.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Bulk ritual to publish all local work and open PRs
+set -euo pipefail
+
+OWNER="${OWNER:-brandonlacoste9-tech}"
+REPO="${REPO:-$(basename -s .git "$(git rev-parse --show-toplevel)")}"
+BASE="${BASE:-main}"
+MSG="${MSG:-chore: send local changes}"
+
+printf '📡 CodexReplay.jobId=%s\n' "${JOB_ID:-local}" >&2
+printf '📦 CodexReplay.sizeBytes=%s\n' "${SIZE_BYTES:-0}" >&2
+printf '🚦 CodexReplay.status=pending\n' >&2
+
+echo "🔐 verifying auth & refreshing remotes"
+gh auth status >/dev/null
+echo "🌐 fetching latest refs"
+git fetch --all --tags --prune
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "🧮 staging and committing working tree"
+  git add -A
+  git commit -m "$MSG"
+else
+  echo "✅ working tree already clean"
+fi
+
+echo "🚢 pushing local branches"
+for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+  git push -u origin "$b"
+done
+
+echo "🏷️ pushing tags"
+git push --tags
+
+echo "🪄 conjuring pull requests"
+for b in $(git for-each-ref --format='%(refname:short)' refs/heads/); do
+  [ "$b" = "$BASE" ] && continue
+  if gh pr list --head "$b" --state all --json number | jq -e 'length>0' >/dev/null; then
+    continue
+  fi
+  if git diff --quiet "$BASE"..."$b"; then
+    continue
+  fi
+  TITLE=$(git log "$BASE".."$b" --pretty=format:'%s' -n 1)
+  BODY="Auto-opened via bulk ritual.\n\nLineage: reference an ADR (e.g., ADR-0002) or CHANGELOG.md."
+  gh pr create --title "${TITLE:-Bulk: $b}" --body "$BODY" --base "$BASE" --head "$b" || true
+done
+
+echo "🏷️ applying foundation labels"
+for pr in $(gh pr list --state open --json number --jq '.[].number'); do
+  gh pr edit "$pr" --add-label "foundation-v1" 2>/dev/null || true
+  gh pr edit "$pr" --add-label "roadmap" 2>/dev/null || true
+  gh pr edit "$pr" --milestone "Q1 — AgentKit & Learn" 2>/dev/null || true
+done
+
+echo "🧮 open PR inventory"
+gh pr list --state open --json number,title,headRefName --jq '.[] | "\(.number)\t\(.headRefName)\t\(.title)"'
+
+printf '🚦 CodexReplay.status=complete\n' >&2
+echo "✅ All rituals complete."


### PR DESCRIPTION
## Summary
- add a reusable bulk-send shell ritual that authenticates, pushes, tags, and opens pull requests
- surface npm run send:all for the ritual and document it in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f017b4fe68832eb073e2327102ad0f