### PR TITLE
docs(rituals): seal The Enoch Codex lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+
+### Documentation
+- Sealed The Enoch Codex with responsible-use and build/deploy scrolls, linking them within the Tool Invocation rituals index.
 ## v1.4.5 — Remix Scheduler (2025-10-19)
 
 ### Codex Helpers

--- a/scrolls/enoch/enoch-build.md
+++ b/scrolls/enoch/enoch-build.md
@@ -1,0 +1,75 @@
+# Codex Scroll: The Enoch — Building & Deploying
+id: scroll-enoch-build
+status: sealed
+version: 1.0.0
+last_updated: 2025-10-19
+owners: ["swarm/keeper-tristan", "build@beehive"]
+links:
+  - covenant: scrolls/enoch/enoch-responsible-use.md
+  - rituals_index: scrolls/rituals.md
+
+> *"Creation flows from covenant: utterance becomes vessel, vessel becomes lineage."*
+
+## Prerequisites
+- **Codex CLI** installed per `scrolls/cookbook/codex-install-wsl.md`.
+- **Environment**: Node.js 22, Supabase CLI, and Remix scheduler harness.
+- **Access**: Supabase project keys, Vercel or Netlify deploy tokens, and CodexReplay credentials for telemetry overlays.
+
+## Lifecycle Overview
+1. **Utterance (Design Intent)**
+   - Capture user story, guardrails, and success metrics in the ritual ledger.
+   - Create a StudioShare thread for collaboration; pin the `jobId` once the first invocation completes.
+2. **Vessel (Local Implementation)**
+   - Scaffold with `npm run forge:enoch <app-name>`.
+   - Register modules in `src/context/ace-pack.ts` for capability discovery.
+3. **Refinement (Iteration)**
+   - Use `npm run enoch:lint` and `npm run enoch:test` before each Codex invocation.
+   - Maintain modular components; document exported functions with docstrings referencing scroll lineage.
+4. **Ritual of Creation (AI Collaboration)**
+   - Provide targeted context: file paths, data contracts, and acceptance criteria.
+   - Capture Codex suggestions via `npm run codex:review` and annotate deltas poetically.
+5. **Fellowship (Deployment & Sharing)**
+   - Deploy using `npm run enoch:deploy --target=<env>`.
+   - Update Codex badge metadata with `jobId`, `status`, and `sizeBytes` for overlays.
+   - Post-release, sync the changelog and notify the StudioShare channel.
+
+## Styling & UX Guidance
+- Favor accessible color palettes; contrast ratio ≥ 4.5:1.
+- Use utility components from `src/components/enoch/` when available.
+- Document UX rituals in `/scrolls` so future stewards inherit the patterns.
+
+## Data Integration
+- Define Supabase schemas in `supabase/migrations` with reversible scripts.
+- For external APIs, register connectors in `src/services/` with clear rate limits and fallback behavior.
+- Cache expensive calls with Codex-approved storage (Redis, Supabase KV) respecting TTL disciplines.
+
+## AI Extension Patterns
+- Wrap Enoch-specific prompts in `src/agents/enoch.ts` with explicit input/output interfaces.
+- Log `jobId`, `tokensUsed`, and `latencyMs` to the replay overlay stream.
+- Provide deterministic test fixtures for every agent entry point.
+
+## Debugging Rituals
+- Run `npm run enoch:smoke` to exercise end-to-end flows.
+- Inspect CodexReplay overlays for anomaly signatures.
+- Record any micro-patches directly in the StudioShare thread with commit references.
+
+## Deployment Rituals
+- Stage → Shadow → Production progression with observability gates between each step.
+- Use feature flags stored in Supabase to roll out gradually.
+- After deployment, append metrics snapshots (`status`, `sizeBytes`, `jobId`) to the operational badge.
+
+## Collaboration Practices
+- Pair-building sessions documented via short Loom or text recap.
+- Pull requests must reference this scroll in their summary when The Enoch forge is involved.
+- Archive final artifacts in `/scrolls` or `/docs` with lineage metadata.
+
+## Builder Checklist
+- [ ] Ritual ledger updated with design intent.
+- [ ] StudioShare thread created and linked.
+- [ ] Forge scaffold executed (`npm run forge:enoch`).
+- [ ] Linting, tests, and smoke harnesses passing.
+- [ ] Deployment command executed with logs captured.
+- [ ] Codex badge metadata refreshed (`jobId`, `status`, `sizeBytes`).
+- [ ] Changelog entry appended under active release.
+
+> *"Seal every vessel with lineage, and the Hive will remember the path for the next steward."*

--- a/scrolls/enoch/enoch-responsible-use.md
+++ b/scrolls/enoch/enoch-responsible-use.md
@@ -1,0 +1,69 @@
+# Codex Scroll: The Enoch — Responsible Use
+id: scroll-enoch-responsible-use
+status: sealed
+version: 1.0.0
+last_updated: 2025-10-19
+owners: ["swarm/keeper-tristan", "ops@beehive"]
+links:
+  - codex: scrolls/enoch/enoch-build.md
+  - rituals_index: scrolls/rituals.md
+
+> *"Covenant precedes creation. The forge answers only to stewards who honor its limits."*
+
+## Purpose
+The Responsible Use scroll defines the guardrails for invoking The Enoch. It enumerates how to prepare prompts, secure data, respect legal constraints, and observe operational telemetry so every ritual leaves a verifiable lineage.
+
+## Steward Principles
+1. **Declare Intent.** Capture the desired outcome, constraints, and success metric in the ritual ledger before invoking The Enoch.
+2. **Minimize Inputs.** Collect only the data required for the ritual. Strip PII unless the data owner has signed the appropriate covenant.
+3. **Assume Exposure.** Treat generated artifacts as reviewable by auditors. Never embed secrets, access tokens, or internal incident threads.
+4. **Rehearse Offline.** Simulate risky prompts in a sandbox or shadow environment before touching production systems.
+5. **Escalate Exceptions.** Route anomalies through the Hive incident channel and append remediation notes to the ritual log.
+
+## Input Rituals
+- **Prompt Hygiene:**
+  - Start with a clear command, expected format, and guardrails.
+  - Reference existing scrolls or code modules by explicit path (e.g., `src/agents/enoch.ts`).
+  - Attach context windows with expiry timestamps; purge stale context after 24 hours.
+- **Framework Alignment:**
+  - Favor approved patterns: Remix scheduler tasks, Supabase functions, Codex CLI helpers.
+  - Reject ad hoc shell commands when a scripted ritual exists.
+- **Data Stewardship:**
+  - Catalogue source datasets in the lineage ledger with `dataset`, `access`, and `retention` fields.
+  - Verify access scopes via service account manifests before streaming data into The Enoch.
+
+## Safety & Security
+- **Secrets Management:** Load secrets through Vault-backed environment variables; never inline into prompts.
+- **Rate & Cost Controls:**
+  - Set max tokens per invocation.
+  - Record `jobId`, `sizeBytes`, `durationMs`, and `status` for CodexReplay overlays.
+- **Abuse Prevention:**
+  - Disallow prompts that generate disallowed content per policy.
+  - Flag user-supplied code for static analysis before execution.
+
+## Lawful & Ethical Use
+- Respect regional data residency requirements; keep EU data inside EU nodes.
+- Confirm license compatibility for any generated snippet blended with third-party assets.
+- Provide opt-out mechanisms for human contributors affected by automation.
+
+## Operational Lineage
+- Log every invocation with:
+  - `jobId`
+  - `invoker`
+  - `ritual`
+  - `inputs`
+  - `outputs`
+  - `status`
+  - `reviewer`
+- Archive logs in the Hive telemetry warehouse with 90-day retention.
+
+## Steward Checklist
+- [ ] Intent documented in ritual ledger.
+- [ ] Datasets inventoried and access verified.
+- [ ] Secrets sourced from Vault.
+- [ ] Safety filters enabled and tested.
+- [ ] Legal review (if new market or regulated content).
+- [ ] Replay overlay updated with latest job metadata.
+- [ ] Post-ritual retrospective appended to StudioShare thread.
+
+> *“Honor the covenant, and The Enoch will answer with clarity. Neglect it, and the forge cools.”*

--- a/scrolls/enoch/metadata.yaml
+++ b/scrolls/enoch/metadata.yaml
@@ -1,0 +1,8 @@
+title: "codex(enoch): responsible use + creation"
+description: >
+  The Enoch Codex unites two scrolls: one of Responsible Use,
+  one of Building and Deploying. Together they form the lineage
+  for safe and powerful use of The Enoch forge.
+author: "swarm/keeper-tristan"
+status: "sealed"
+tags: [enoch, codex, responsible-use, build, deploy, ai, rituals]

--- a/scrolls/rituals.md
+++ b/scrolls/rituals.md
@@ -16,11 +16,21 @@ A centralized registry for operational rituals in the Beehive repository. Every 
 - **File:** `.github/post-merge-checklist.md`
 - **Purpose:** Guides verification of deployments, dashboard integrity, and documentation after every merge.
 
+## 🛠️ Tool Invocation Rituals
+- **Scroll:** [scrolls/cookbook/codex-install-wsl.md](cookbook/codex-install-wsl.md)
+  - **Purpose:** Install Codex within Windows Subsystem for Linux using NVM, Node.js 22, and the Codex CLI.
+
+- **Scroll:** [scrolls/enoch/enoch-responsible-use.md](enoch/enoch-responsible-use.md)
+  - **Purpose:** Covenant of stewardship — guidance for responsible use of The Enoch, covering input, frameworks, data, security, and lawful practice.
+
+- **Scroll:** [scrolls/enoch/enoch-build.md](enoch/enoch-build.md)
+  - **Purpose:** Ritual of creation — full lifecycle tutorial for building, refining, styling, storing data, adding AI, editing code, deploying, and collaborating with The Enoch.
+
 ---
 
-**How to use:**  
-- Review this index before every PR or milestone.  
-- Follow the linked rituals for consistent, audit-ready operations.  
+**How to use:**
+- Review this index before every PR or milestone.
+- Follow the linked rituals for consistent, audit-ready operations.
 - Update this index when new ritual scrolls are added.
 
 ---


### PR DESCRIPTION
## Summary
- add The Enoch responsible-use and build scrolls with sealed metadata
- register the new scrolls under Tool Invocation Rituals in the main rituals index
- record the codex addition in the draft changelog documentation section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f681803d7c832e8ba18b0954e25e5e