### PR TITLE
Add CODEX agents namespace and OpenAPI schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Bee Swarm Agents (AGENTS.md) — CODEX Ledger
+
+## Quickstart
+- Define/edit agents in this file (and optionally mirror to `data/agents.json`).
+- Expose standard routes: `/api/codex/agents/:id/run`, `/api/codex/agents/:id/tools/:tool`, `/api/codex/agents/:id/memory`.
+- Correlate every call with the `x-codex-run` header.
+
+## Agents
+
+| id       | domain                | personality (short)    | key skills                              | default triggers                    |
+| -------- | --------------------- | ---------------------- | --------------------------------------- | ----------------------------------- |
+| nexus    | admin/scheduling      | calm, organized EA     | calendar sync, email triage, notes      | `/api/codex/agents/nexus/run`       |
+| ledger   | finance/accounting    | precise, formal CPA    | invoice gen, parts costing, spend audit | `/api/codex/agents/ledger/run`      |
+| harvest  | ops (restaurant)      | direct, fast manager   | shift board, prep lists, inventory      | `/api/codex/agents/harvest/run`     |
+| forge    | auto/mechanics        | diagnostic, pragmatic  | symptom intake, repair estimate, parts  | `/api/codex/agents/forge/run`       |
+| spark    | electrical systems    | schematic-minded, safe | breaker trace, load calc, BOM           | `/api/codex/agents/spark/run`       |
+| hydro    | plumbing              | methodical, code-aware | leak triage, pipe layout, materials     | `/api/codex/agents/hydro/run`       |
+| triage   | med intake            | calm, empathetic       | intake forms, vitals, route of care     | `/api/codex/agents/triage/run`      |
+| medic    | medical knowledge     | professional, cautious | guideline lookup, patient info sheet    | `/api/codex/agents/medic/run`       |
+| design   | UX/brand (leafcutter) | precise, aesthetic     | logo briefs, palette, typography recs   | `/api/codex/agents/design/run`      |
+| firewall | security              | strict, no-nonsense    | spam/abuse filter, IP risk, 2FA nudges  | `/api/codex/agents/firewall/run`    |
+| buzz     | social ads            | upbeat, punchy         | headlines, captions, hashtag sets       | `/api/codex/agents/buzz/run`        |
+| research | academic (mining)     | thorough, cited        | source gather, summary, bibtex          | `/api/codex/agents/research/run`    |
+
+## API surface
+
+* `POST /api/codex/agents/:id/run`
+* `POST /api/codex/agents/:id/tools/:tool`
+* `GET /api/codex/agents/:id/memory?cursor=...`
+
+### Example
+
+```
+curl -sX POST /api/codex/agents/nexus/run \
+  -H 'content-type: application/json' \
+  -d '{"task":"schedule","inputs":{"query":"book 30m with Alex next Tue 2-4pm"}}'
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+### CODEX Ledger
+- Namespaced agent routes under `/api/codex/agents/*` with run/tool/memory scaffolds and `x-codex-run` correlation headers.
+- Published `/api/codex/openapi` with the CODEX Agents OpenAPI contract and refreshed `AGENTS.md` ledger entries.
 ## v1.4.5 — Remix Scheduler (2025-10-19)
 
 ### Codex Helpers

--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ All operational rituals and checklists are centralized in [scrolls/rituals.md](s
 Every merge, seal, and ceremony is documented for the swarm.
 
 > Start here to follow the Hive’s path.
+
+### 🧭 CODEX Agents API
+
+- **OpenAPI**: `/api/codex/openapi`
+- **Agents ledger**: `AGENTS.md`
+- **Base routes**:
+  - `POST /api/codex/agents/:id/run`
+  - `POST /api/codex/agents/:id/tools/:tool`
+  - `GET  /api/codex/agents/:id/memory`
+
+Badges (wire to your CI):
+
+[![CI](https://img.shields.io/badge/ci-codex-green)](#)
+[![OpenAPI](https://img.shields.io/badge/openapi-codex-blue)](/api/codex/openapi)
+

--- a/openapi/codex.openapi.json
+++ b/openapi/codex.openapi.json
@@ -1,0 +1,128 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "CODEX Agents API",
+    "version": "0.1.0",
+    "description": "Namespaced API surface for Bee Swarm agents. Contracts mirror AGENTS.md. Correlate requests with the `x-codex-run` header."
+  },
+  "servers": [{ "url": "/" }],
+  "paths": {
+    "/api/codex/agents/{id}/run": {
+      "post": {
+        "summary": "Run an agent task",
+        "operationId": "codexRun",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/AgentRunRequest" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AgentRunResponse" } } } },
+          "400": { "description": "Bad Request" },
+          "429": { "description": "Rate Limited" }
+        }
+      }
+    },
+    "/api/codex/agents/{id}/tools/{tool}": {
+      "post": {
+        "summary": "Invoke an agent tool",
+        "operationId": "codexToolInvoke",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "tool", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "type": "object", "additionalProperties": true } }
+          }
+        },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ToolInvokeResponse" } } } },
+          "400": { "description": "Bad Request" },
+          "429": { "description": "Rate Limited" }
+        }
+      }
+    },
+    "/api/codex/agents/{id}/memory": {
+      "get": {
+        "summary": "List recent memory items",
+        "operationId": "codexMemoryList",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string", "nullable": true } }
+        ],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/MemoryListResponse" } } } },
+          "400": { "description": "Bad Request" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AgentRunRequest": {
+        "type": "object",
+        "required": ["task"],
+        "properties": {
+          "task": { "type": "string", "description": "Human instruction or task name" },
+          "inputs": { "type": "object", "additionalProperties": true },
+          "runId": { "type": "string", "nullable": true }
+        }
+      },
+      "AgentRunResponse": {
+        "type": "object",
+        "required": ["ok", "runId"],
+        "properties": {
+          "ok": { "type": "boolean" },
+          "runId": { "type": "string" },
+          "output": { "type": "object", "additionalProperties": true },
+          "tokens": {
+            "type": "object",
+            "properties": {
+              "input": { "type": "integer" },
+              "output": { "type": "integer" }
+            },
+            "nullable": true
+          },
+          "error": { "type": "string", "nullable": true }
+        }
+      },
+      "ToolInvokeResponse": {
+        "type": "object",
+        "required": ["ok", "runId"],
+        "properties": {
+          "ok": { "type": "boolean" },
+          "runId": { "type": "string" },
+          "result": { "type": "object", "additionalProperties": true, "nullable": true },
+          "error": { "type": "string", "nullable": true }
+        }
+      },
+      "MemoryListResponse": {
+        "type": "object",
+        "required": ["ok", "runId", "items"],
+        "properties": {
+          "ok": { "type": "boolean" },
+          "runId": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "type": { "type": "string" },
+                "payload": { "type": "object", "additionalProperties": true },
+                "ts": { "type": "string", "format": "date-time" }
+              }
+            }
+          },
+          "nextCursor": { "type": "string", "nullable": true }
+        }
+      }
+    }
+  }
+}

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "codex_agents_api",
+    "version": "1.0.0-draft",
+    "enabled": true
   }
 ]

--- a/src/app/api/codex/agents/[id]/memory/route.ts
+++ b/src/app/api/codex/agents/[id]/memory/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import { requireCodexAgent, correlationHeaders } from '@/lib/codexAgents';
+
+export const runtime = 'nodejs';
+
+export async function GET(_req: Request, ctx: { params: { id: string } }) {
+  const runId = randomUUID();
+  const { id } = ctx.params;
+
+  try {
+    requireCodexAgent(id);
+    return NextResponse.json(
+      { ok: true, runId, items: [], nextCursor: null },
+      { headers: correlationHeaders(runId) },
+    );
+  } catch (err: any) {
+    const status = typeof err?.status === 'number' ? err.status : 400;
+    const message = err?.message ?? 'error';
+    return NextResponse.json(
+      { ok: false, runId, error: message },
+      { status, headers: correlationHeaders(runId) },
+    );
+  }
+}

--- a/src/app/api/codex/agents/[id]/run/route.ts
+++ b/src/app/api/codex/agents/[id]/run/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import {
+  requireCodexAgent,
+  requireJSON,
+  correlationHeaders,
+  rateLimit,
+} from '@/lib/codexAgents';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request, ctx: { params: { id: string } }) {
+  const runId = randomUUID();
+  const { id } = ctx.params;
+
+  try {
+    const agent = requireCodexAgent(id);
+    const body = await requireJSON(req);
+    const task = typeof body?.task === 'string' ? body.task.trim() : '';
+    if (!task) {
+      throw httpError(400, 'missing task');
+    }
+
+    const inputs = body?.inputs && typeof body.inputs === 'object' ? body.inputs : {};
+    const rpm = agent.entitlements?.limits?.rpm ?? 60;
+    rateLimit(`agent:${id}`, rpm);
+
+    const output = {
+      echo: { task, inputs },
+      note: 'stub',
+    };
+
+    return NextResponse.json(
+      {
+        ok: true,
+        runId,
+        output,
+        tokens: { input: 0, output: 0 },
+      },
+      { headers: correlationHeaders(runId) },
+    );
+  } catch (err: any) {
+    const status = typeof err?.status === 'number' ? err.status : 400;
+    const message = err?.message ?? 'error';
+    return NextResponse.json(
+      { ok: false, runId, error: message },
+      { status, headers: correlationHeaders(runId) },
+    );
+  }
+}
+
+function httpError(status: number, message: string) {
+  const error = new Error(message) as Error & { status?: number };
+  error.status = status;
+  return error;
+}

--- a/src/app/api/codex/agents/[id]/tools/[tool]/route.ts
+++ b/src/app/api/codex/agents/[id]/tools/[tool]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { randomUUID } from 'node:crypto';
+import {
+  requireCodexAgent,
+  requireJSON,
+  correlationHeaders,
+  rateLimit,
+} from '@/lib/codexAgents';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: Request, ctx: { params: { id: string; tool: string } }) {
+  const runId = randomUUID();
+  const { id, tool } = ctx.params;
+
+  try {
+    const agent = requireCodexAgent(id);
+    const payload = await requireJSON(req);
+    const rpm = agent.entitlements?.limits?.rpm ?? 60;
+    rateLimit(`agent:${id}:tool:${tool}`, rpm);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        runId,
+        result: { tool, inputs: payload ?? {} },
+      },
+      { headers: correlationHeaders(runId) },
+    );
+  } catch (err: any) {
+    const status = typeof err?.status === 'number' ? err.status : 400;
+    const message = err?.message ?? 'error';
+    return NextResponse.json(
+      { ok: false, runId, error: message },
+      { status, headers: correlationHeaders(runId) },
+    );
+  }
+}

--- a/src/app/api/codex/openapi/route.ts
+++ b/src/app/api/codex/openapi/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const runtime = 'nodejs';
+
+export function GET() {
+  const filePath = join(process.cwd(), 'openapi', 'codex.openapi.json');
+  const raw = readFileSync(filePath, 'utf8');
+  return new NextResponse(raw, {
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'public, max-age=60',
+    },
+  });
+}

--- a/src/lib/codexAgents.ts
+++ b/src/lib/codexAgents.ts
@@ -1,0 +1,150 @@
+export type AgentTrigger = {
+  http?: string[];
+  cron?: string;
+};
+
+export type AgentEntitlements = {
+  limits?: {
+    rpm?: number;
+  };
+};
+
+export type CodexAgent = {
+  id: string;
+  domain: string;
+  personality: string;
+  skills: string;
+  triggers: AgentTrigger;
+  entitlements?: AgentEntitlements;
+};
+
+type HttpError = Error & { status?: number };
+
+const AGENTS: CodexAgent[] = [
+  {
+    id: 'nexus',
+    domain: 'admin/scheduling',
+    personality: 'calm, organized EA',
+    skills: 'calendar sync, email triage, notes',
+    triggers: { http: ['/api/codex/agents/nexus/run'] },
+    entitlements: { limits: { rpm: 60 } },
+  },
+  {
+    id: 'ledger',
+    domain: 'finance/accounting',
+    personality: 'precise, formal CPA',
+    skills: 'invoice gen, parts costing, spend audit',
+    triggers: { http: ['/api/codex/agents/ledger/run'] },
+    entitlements: { limits: { rpm: 45 } },
+  },
+  {
+    id: 'harvest',
+    domain: 'ops (restaurant)',
+    personality: 'direct, fast manager',
+    skills: 'shift board, prep lists, inventory',
+    triggers: { http: ['/api/codex/agents/harvest/run'] },
+  },
+  {
+    id: 'forge',
+    domain: 'auto/mechanics',
+    personality: 'diagnostic, pragmatic',
+    skills: 'symptom intake, repair estimate, parts',
+    triggers: { http: ['/api/codex/agents/forge/run'] },
+  },
+  {
+    id: 'spark',
+    domain: 'electrical systems',
+    personality: 'schematic-minded, safe',
+    skills: 'breaker trace, load calc, BOM',
+    triggers: { http: ['/api/codex/agents/spark/run'] },
+  },
+  {
+    id: 'hydro',
+    domain: 'plumbing',
+    personality: 'methodical, code-aware',
+    skills: 'leak triage, pipe layout, materials',
+    triggers: { http: ['/api/codex/agents/hydro/run'] },
+  },
+  {
+    id: 'triage',
+    domain: 'med intake',
+    personality: 'calm, empathetic',
+    skills: 'intake forms, vitals, route of care',
+    triggers: { http: ['/api/codex/agents/triage/run'] },
+  },
+  {
+    id: 'medic',
+    domain: 'medical knowledge',
+    personality: 'professional, cautious',
+    skills: 'guideline lookup, patient info sheet',
+    triggers: { http: ['/api/codex/agents/medic/run'] },
+  },
+  {
+    id: 'design',
+    domain: 'UX/brand (leafcutter)',
+    personality: 'precise, aesthetic',
+    skills: 'logo briefs, palette, typography recs',
+    triggers: { http: ['/api/codex/agents/design/run'] },
+  },
+  {
+    id: 'firewall',
+    domain: 'security',
+    personality: 'strict, no-nonsense',
+    skills: 'spam/abuse filter, IP risk, 2FA nudges',
+    triggers: { http: ['/api/codex/agents/firewall/run'] },
+  },
+  {
+    id: 'buzz',
+    domain: 'social ads',
+    personality: 'upbeat, punchy',
+    skills: 'headlines, captions, hashtag sets',
+    triggers: { http: ['/api/codex/agents/buzz/run'] },
+  },
+  {
+    id: 'research',
+    domain: 'academic (mining)',
+    personality: 'thorough, cited',
+    skills: 'source gather, summary, bibtex',
+    triggers: { http: ['/api/codex/agents/research/run'] },
+  },
+];
+
+const LEDGER = new Map(AGENTS.map((agent) => [agent.id, agent]));
+
+export function listCodexAgents() {
+  return AGENTS;
+}
+
+export function getCodexAgent(id: string) {
+  return LEDGER.get(id);
+}
+
+export function requireCodexAgent(id: string) {
+  const agent = getCodexAgent(id);
+  if (!agent) {
+    throw httpError(404, `unknown agent: ${id}`);
+  }
+  return agent;
+}
+
+export async function requireJSON(req: Request) {
+  try {
+    return await req.json();
+  } catch (err) {
+    throw httpError(400, 'invalid JSON body');
+  }
+}
+
+export function correlationHeaders(runId: string) {
+  return { 'x-codex-run': runId };
+}
+
+export function rateLimit(_key: string, _rpm = 60) {
+  return;
+}
+
+function httpError(status: number, message: string) {
+  const error = new Error(message) as HttpError;
+  error.status = status;
+  return error;
+}


### PR DESCRIPTION
## Summary
- add CODEX ledger documentation and update the swarm changelog/index
- expose namespaced `/api/codex/agents` run/tool/memory routes that emit `x-codex-run`
- publish the CODEX OpenAPI contract and surface the endpoints in the README

## Testing
- not run (not available in repository)

------
https://chatgpt.com/codex/tasks/task_b_68f6ccd45cb0832eb569126e8965e01d