### PR TITLE
Add Codex ritual pipeline scripts and status outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+.env
+.env.*

--- a/docs/codex-index.json
+++ b/docs/codex-index.json
@@ -1,0 +1,126 @@
+{
+  "meta": {
+    "generatedAt": "2025-10-20T23:55:08.588Z",
+    "jobId": "codex-index-20251020235508",
+    "scrollCount": 8,
+    "totalSizeBytes": 4148
+  },
+  "statuses": {
+    "draft": 8
+  },
+  "scrolls": [
+    {
+      "id": "scroll-advanced-budget-models",
+      "title": "Codex Scroll: Advanced Budget Models",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [
+        "ops@beehive"
+      ],
+      "links": [
+        {
+          "label": "belief_ledger",
+          "url": "bq://adgenxai_ops.belief_ledger"
+        },
+        {
+          "label": "audit",
+          "url": "bq://adgenxai_ops.budget_actions"
+        },
+        {
+          "label": "diagram",
+          "url": "docs/diagrams/coe-bayesian-rl-integration.png"
+        }
+      ],
+      "path": "scrolls/advanced-budget-models.md",
+      "excerpt": "Bayesian + bandit policy for budget allocation; shadow-first with guardrails.",
+      "sizeBytes": 1049
+    },
+    {
+      "id": "scroll-anywhere",
+      "title": "Codex Scroll: BeeHive Anywhere Blueprint",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/beehive-anywhere-blueprint.md",
+      "excerpt": "Run the Hive across environments (cloud, on-prem, air-gapped), with a minimal adapter layer and signed capabilities.",
+      "sizeBytes": 402
+    },
+    {
+      "id": "scroll-budget-adapter",
+      "title": "Codex Scroll: Budget Adapter Service",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [
+        "ads@beehive"
+      ],
+      "links": [],
+      "path": "scrolls/budget-adapter-service.md",
+      "excerpt": "Uniform `/POST {provider}/budget` API to sync directives to ad networks.",
+      "sizeBytes": 609
+    },
+    {
+      "id": "scroll-orchestrator",
+      "title": "Codex Scroll: Campaign Orchestration",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/campaign-orchestration.md",
+      "excerpt": "1) Fetch active campaigns (Registry)",
+      "sizeBytes": 482
+    },
+    {
+      "id": "scroll-governance",
+      "title": "Codex Scroll: Governance Dashboards",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/governance-dashboards.md",
+      "excerpt": "Daily Agent Integrity",
+      "sizeBytes": 348
+    },
+    {
+      "id": "scroll-psa",
+      "title": "Codex Scroll: Predictive Scorecard Agent (PSA)",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/predictive-scorecard-agent.md",
+      "excerpt": "Compute reward r_t and stability flags from ROI/engagement/volatility.",
+      "sizeBytes": 427
+    },
+    {
+      "id": "scroll-rl-trainer",
+      "title": "Codex Scroll: RL Policy Trainer Agent",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/rl-policy-trainer-agent.md",
+      "excerpt": "Replay: join `belief_ledger` × `budget_actions` × rewards",
+      "sizeBytes": 420
+    },
+    {
+      "id": "scroll-viral-forge",
+      "title": "Codex Scroll: Viral Forge Autoproducer (Revenue Intel)",
+      "status": "draft",
+      "version": "0.1.0",
+      "lastUpdated": "2025-10-15",
+      "owners": [],
+      "links": [],
+      "path": "scrolls/viral-forge-autoproducer.md",
+      "excerpt": "Generate hooks/ad copy/montage tuned to live sentiment; export artifacts (.md/.json).",
+      "sizeBytes": 411
+    }
+  ]
+}

--- a/docs/codex-status.md
+++ b/docs/codex-status.md
@@ -1,0 +1,29 @@
+---
+jobId: codex-index-20251020235508
+generatedAt: 2025-10-20T23:55:08.588Z
+scrollCount: 8
+totalSizeBytes: 4148
+---
+
+# Codex Status Ledger
+
+Glyph ledger for Codex scroll exports.
+
+| Glyph | Status | Count |
+| :---- | :----- | ----: |
+| 🟡 | Draft | 8 |
+
+## Scroll Directory
+
+| Glyph | Scroll | Status | Version | Last Updated | Owners | Size | Excerpt |
+| :---- | :----- | :----- | :------ | :----------- | :----- | ----: | :------ |
+| 🟡 | [Codex Scroll: Advanced Budget Models](../scrolls/advanced-budget-models.md) | Draft | 0.1.0 | 2025-10-15 | ops@beehive | 1.0 kB (1049 B) | Bayesian + bandit policy for budget allocation; shadow-first with guardrails. |
+| 🟡 | [Codex Scroll: BeeHive Anywhere Blueprint](../scrolls/beehive-anywhere-blueprint.md) | Draft | 0.1.0 | 2025-10-15 | — | 402 B (402 B) | Run the Hive across environments (cloud, on-prem, air-gapped), with a minimal adapter layer and signed capabilities. |
+| 🟡 | [Codex Scroll: Budget Adapter Service](../scrolls/budget-adapter-service.md) | Draft | 0.1.0 | 2025-10-15 | ads@beehive | 609 B (609 B) | Uniform `/POST {provider}/budget` API to sync directives to ad networks. |
+| 🟡 | [Codex Scroll: Campaign Orchestration](../scrolls/campaign-orchestration.md) | Draft | 0.1.0 | 2025-10-15 | — | 482 B (482 B) | 1) Fetch active campaigns (Registry) |
+| 🟡 | [Codex Scroll: Governance Dashboards](../scrolls/governance-dashboards.md) | Draft | 0.1.0 | 2025-10-15 | — | 348 B (348 B) | Daily Agent Integrity |
+| 🟡 | [Codex Scroll: Predictive Scorecard Agent (PSA)](../scrolls/predictive-scorecard-agent.md) | Draft | 0.1.0 | 2025-10-15 | — | 427 B (427 B) | Compute reward r_t and stability flags from ROI/engagement/volatility. |
+| 🟡 | [Codex Scroll: RL Policy Trainer Agent](../scrolls/rl-policy-trainer-agent.md) | Draft | 0.1.0 | 2025-10-15 | — | 420 B (420 B) | Replay: join `belief_ledger` × `budget_actions` × rewards |
+| 🟡 | [Codex Scroll: Viral Forge Autoproducer (Revenue Intel)](../scrolls/viral-forge-autoproducer.md) | Draft | 0.1.0 | 2025-10-15 | — | 411 B (411 B) | Generate hooks/ad copy/montage tuned to live sentiment; export artifacts (.md/.json). |
+
+<!-- Generated via npm run codex:render -->

--- a/fixtures/expected-codex-status.md
+++ b/fixtures/expected-codex-status.md
@@ -1,0 +1,29 @@
+---
+jobId: codex-index-20251020235508
+generatedAt: 2025-10-20T23:55:08.588Z
+scrollCount: 8
+totalSizeBytes: 4148
+---
+
+# Codex Status Ledger
+
+Glyph ledger for Codex scroll exports.
+
+| Glyph | Status | Count |
+| :---- | :----- | ----: |
+| 🟡 | Draft | 8 |
+
+## Scroll Directory
+
+| Glyph | Scroll | Status | Version | Last Updated | Owners | Size | Excerpt |
+| :---- | :----- | :----- | :------ | :----------- | :----- | ----: | :------ |
+| 🟡 | [Codex Scroll: Advanced Budget Models](../scrolls/advanced-budget-models.md) | Draft | 0.1.0 | 2025-10-15 | ops@beehive | 1.0 kB (1049 B) | Bayesian + bandit policy for budget allocation; shadow-first with guardrails. |
+| 🟡 | [Codex Scroll: BeeHive Anywhere Blueprint](../scrolls/beehive-anywhere-blueprint.md) | Draft | 0.1.0 | 2025-10-15 | — | 402 B (402 B) | Run the Hive across environments (cloud, on-prem, air-gapped), with a minimal adapter layer and signed capabilities. |
+| 🟡 | [Codex Scroll: Budget Adapter Service](../scrolls/budget-adapter-service.md) | Draft | 0.1.0 | 2025-10-15 | ads@beehive | 609 B (609 B) | Uniform `/POST {provider}/budget` API to sync directives to ad networks. |
+| 🟡 | [Codex Scroll: Campaign Orchestration](../scrolls/campaign-orchestration.md) | Draft | 0.1.0 | 2025-10-15 | — | 482 B (482 B) | 1) Fetch active campaigns (Registry) |
+| 🟡 | [Codex Scroll: Governance Dashboards](../scrolls/governance-dashboards.md) | Draft | 0.1.0 | 2025-10-15 | — | 348 B (348 B) | Daily Agent Integrity |
+| 🟡 | [Codex Scroll: Predictive Scorecard Agent (PSA)](../scrolls/predictive-scorecard-agent.md) | Draft | 0.1.0 | 2025-10-15 | — | 427 B (427 B) | Compute reward r_t and stability flags from ROI/engagement/volatility. |
+| 🟡 | [Codex Scroll: RL Policy Trainer Agent](../scrolls/rl-policy-trainer-agent.md) | Draft | 0.1.0 | 2025-10-15 | — | 420 B (420 B) | Replay: join `belief_ledger` × `budget_actions` × rewards |
+| 🟡 | [Codex Scroll: Viral Forge Autoproducer (Revenue Intel)](../scrolls/viral-forge-autoproducer.md) | Draft | 0.1.0 | 2025-10-15 | — | 411 B (411 B) | Generate hooks/ad copy/montage tuned to live sentiment; export artifacts (.md/.json). |
+
+<!-- Generated via npm run codex:render -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "beehive",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "beehive",
+      "devDependencies": {
+        "tsx": "^4.7.1",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
+      "integrity": "sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.11.tgz",
+      "integrity": "sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.11.tgz",
+      "integrity": "sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.11.tgz",
+      "integrity": "sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz",
+      "integrity": "sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.11.tgz",
+      "integrity": "sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.11.tgz",
+      "integrity": "sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.11.tgz",
+      "integrity": "sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.11.tgz",
+      "integrity": "sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.11.tgz",
+      "integrity": "sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.11.tgz",
+      "integrity": "sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.11.tgz",
+      "integrity": "sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.11.tgz",
+      "integrity": "sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.11.tgz",
+      "integrity": "sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz",
+      "integrity": "sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.11.tgz",
+      "integrity": "sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.11.tgz",
+      "integrity": "sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.11.tgz",
+      "integrity": "sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.11.tgz",
+      "integrity": "sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.11.tgz",
+      "integrity": "sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.11.tgz",
+      "integrity": "sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.11.tgz",
+      "integrity": "sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.11.tgz",
+      "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.11",
+        "@esbuild/android-arm": "0.25.11",
+        "@esbuild/android-arm64": "0.25.11",
+        "@esbuild/android-x64": "0.25.11",
+        "@esbuild/darwin-arm64": "0.25.11",
+        "@esbuild/darwin-x64": "0.25.11",
+        "@esbuild/freebsd-arm64": "0.25.11",
+        "@esbuild/freebsd-x64": "0.25.11",
+        "@esbuild/linux-arm": "0.25.11",
+        "@esbuild/linux-arm64": "0.25.11",
+        "@esbuild/linux-ia32": "0.25.11",
+        "@esbuild/linux-loong64": "0.25.11",
+        "@esbuild/linux-mips64el": "0.25.11",
+        "@esbuild/linux-ppc64": "0.25.11",
+        "@esbuild/linux-riscv64": "0.25.11",
+        "@esbuild/linux-s390x": "0.25.11",
+        "@esbuild/linux-x64": "0.25.11",
+        "@esbuild/netbsd-arm64": "0.25.11",
+        "@esbuild/netbsd-x64": "0.25.11",
+        "@esbuild/openbsd-arm64": "0.25.11",
+        "@esbuild/openbsd-x64": "0.25.11",
+        "@esbuild/openharmony-arm64": "0.25.11",
+        "@esbuild/sunos-x64": "0.25.11",
+        "@esbuild/win32-arm64": "0.25.11",
+        "@esbuild/win32-ia32": "0.25.11",
+        "@esbuild/win32-x64": "0.25.11"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
+      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "beehive",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "codex:generate": "tsx scripts/codex/generate-index.ts",
+    "codex:render": "tsx scripts/codex/render-status.ts",
+    "codex:validate": "tsx scripts/codex/validate-index.ts",
+    "codex:check-snapshot": "tsx scripts/codex/check-status-snapshot.ts",
+    "codex:notify": "tsx scripts/codex/notify.ts",
+    "codex:guard": "npm run codex:validate && npm run codex:check-snapshot",
+    "codex:ritual": "npm run codex:generate && npm run codex:render && npm run codex:validate && npm run codex:notify",
+    "smoke": "npm run codex:render && npm run codex:validate && DRY_RUN=true npm run codex:notify",
+    "update-snapshot": "tsx scripts/codex/update-status-snapshot.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.1",
+    "zod": "^3.23.8"
+  }
+}

--- a/scripts/codex/check-status-snapshot.ts
+++ b/scripts/codex/check-status-snapshot.ts
@@ -1,0 +1,37 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+function normalize(value: string): string {
+  return value.replace(/\r\n/g, '\n').trim();
+}
+
+async function main() {
+  const root = process.cwd();
+  const actualPath = path.resolve(root, 'docs', 'codex-status.md');
+  const expectedPath = path.resolve(root, 'fixtures', 'expected-codex-status.md');
+
+  const [actual, expected] = await Promise.all([
+    fs.readFile(actualPath, 'utf8').catch((err) => {
+      throw new Error(`Missing codex status at ${actualPath}: ${(err as Error).message}`);
+    }),
+    fs.readFile(expectedPath, 'utf8').catch((err) => {
+      throw new Error(
+        `Missing snapshot at ${expectedPath}: ${(err as Error).message}\nRun \"npm run update-snapshot\" after rendering.`
+      );
+    }),
+  ]);
+
+  if (normalize(actual) !== normalize(expected)) {
+    throw new Error(
+      'Codex status snapshot mismatch. Re-run the ritual (npm run codex:ritual) and update the snapshot via npm run update-snapshot if the changes are intentional.'
+    );
+  }
+
+  console.log('🛡️  Codex status snapshot verified.');
+}
+
+main().catch((err) => {
+  console.error('Snapshot guard failed.');
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/scripts/codex/common.ts
+++ b/scripts/codex/common.ts
@@ -1,0 +1,208 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export type ScrollLink = {
+  label: string;
+  url: string;
+};
+
+export type ScrollRecord = {
+  id: string;
+  title: string;
+  status: string;
+  version: string;
+  lastUpdated: string;
+  owners: string[];
+  links: ScrollLink[];
+  path: string;
+  excerpt: string;
+  sizeBytes: number;
+};
+
+export type CodexIndex = {
+  meta: {
+    generatedAt: string;
+    jobId: string;
+    scrollCount: number;
+    totalSizeBytes: number;
+  };
+  statuses: Record<string, number>;
+  scrolls: ScrollRecord[];
+};
+
+export const STATUS_GLYPHS: Record<string, string> = {
+  active: '🟢',
+  draft: '🟡',
+  review: '🟣',
+  paused: '🟠',
+  deprecated: '⚫',
+  archived: '⚪',
+};
+
+export function glyphForStatus(status: string): string {
+  const key = status.toLowerCase();
+  return STATUS_GLYPHS[key] ?? '⚪';
+}
+
+function toCamel(key: string): string {
+  return key
+    .trim()
+    .toLowerCase()
+    .replace(/[-_]+(\w)/g, (_, ch: string) => ch.toUpperCase());
+}
+
+function parseOwners(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  try {
+    const parsed = JSON.parse(trimmed.replace(/'/g, '"'));
+    return Array.isArray(parsed) ? parsed.map((v) => String(v)) : [];
+  } catch {
+    return trimmed
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+}
+
+function parseLinks(lines: string[], start: number): { links: ScrollLink[]; nextIndex: number } {
+  const links: ScrollLink[] = [];
+  let idx = start + 1;
+  while (idx < lines.length) {
+    const raw = lines[idx];
+    if (!raw || !raw.trim()) {
+      idx += 1;
+      break;
+    }
+    if (!raw.trim().startsWith('-')) break;
+    const cleaned = raw.trim().replace(/^[-\s]+/, '');
+    const colon = cleaned.indexOf(':');
+    let label = cleaned;
+    let url = '';
+    if (colon >= 0) {
+      label = cleaned.slice(0, colon).trim();
+      url = cleaned.slice(colon + 1).trim();
+    }
+    links.push({ label, url });
+    idx += 1;
+  }
+  return { links, nextIndex: idx };
+}
+
+export async function loadScrollRecords(rootDir = process.cwd()): Promise<ScrollRecord[]> {
+  const scrollDir = path.resolve(rootDir, 'scrolls');
+  const entries = await fs.readdir(scrollDir, { withFileTypes: true });
+  const records: ScrollRecord[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    const filePath = path.join(scrollDir, entry.name);
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = parseScrollFile(filePath, content);
+    if (parsed) {
+      records.push(parsed);
+    }
+  }
+
+  return records.sort((a, b) => a.title.localeCompare(b.title));
+}
+
+function parseScrollFile(filePath: string, content: string): ScrollRecord | null {
+  const lines = content.split(/\r?\n/);
+  if (!lines.length) return null;
+
+  let idx = 0;
+  let title = lines[idx].trim();
+  if (title.startsWith('#')) {
+    title = title.replace(/^#+\s*/, '').trim();
+    idx += 1;
+  }
+
+  const meta: Record<string, unknown> = {
+    id: '',
+    status: 'draft',
+    version: '0.0.0',
+    lastUpdated: '',
+    owners: [],
+    links: [],
+  };
+
+  let cursor = idx;
+  while (cursor < lines.length) {
+    const raw = lines[cursor];
+    if (!raw || !raw.trim()) {
+      cursor += 1;
+      break;
+    }
+    if (!raw.includes(':')) break;
+
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('links:')) {
+      const { links, nextIndex } = parseLinks(lines, cursor);
+      meta.links = links;
+      cursor = nextIndex;
+      continue;
+    }
+
+    const colon = trimmed.indexOf(':');
+    if (colon < 0) break;
+    const key = toCamel(trimmed.slice(0, colon));
+    let value = trimmed.slice(colon + 1).trim();
+
+    if (key === 'owners') {
+      meta.owners = parseOwners(value);
+    } else if (key === 'lastUpdated') {
+      meta.lastUpdated = value;
+    } else if (key === 'status' || key === 'version' || key === 'id') {
+      meta[key] = value;
+    } else {
+      meta[key] = value;
+    }
+
+    cursor += 1;
+  }
+
+  const excerpt = extractExcerpt(lines.slice(cursor));
+  const sizeBytes = Buffer.byteLength(content, 'utf8');
+  const record: ScrollRecord = {
+    id: String(meta.id ?? ''),
+    title,
+    status: String(meta.status ?? 'draft'),
+    version: String(meta.version ?? ''),
+    lastUpdated: String(meta.lastUpdated ?? ''),
+    owners: Array.isArray(meta.owners) ? (meta.owners as string[]) : [],
+    links: Array.isArray(meta.links) ? (meta.links as ScrollLink[]) : [],
+    path: path.relative(process.cwd(), filePath),
+    excerpt,
+    sizeBytes,
+  };
+
+  if (!record.id || !record.status) {
+    return null;
+  }
+
+  return record;
+}
+
+function extractExcerpt(lines: string[]): string {
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    if (trimmed.startsWith('- ')) {
+      return trimmed.slice(2).trim();
+    }
+    return trimmed;
+  }
+  return '';
+}
+
+export async function readCodexIndex(rootDir = process.cwd()): Promise<CodexIndex> {
+  const filePath = path.resolve(rootDir, 'docs', 'codex-index.json');
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw) as CodexIndex;
+}
+
+export async function writeFileEnsured(filePath: string, contents: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, contents);
+}

--- a/scripts/codex/generate-index.ts
+++ b/scripts/codex/generate-index.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+
+import { loadScrollRecords, writeFileEnsured } from './common';
+
+async function main() {
+  const root = process.cwd();
+  const scrolls = await loadScrollRecords(root);
+
+  const statuses = scrolls.reduce<Record<string, number>>((acc, scroll) => {
+    const key = scroll.status.toLowerCase();
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const generatedAt = new Date().toISOString();
+  const sanitized = generatedAt.replace(/[-:]/g, '').replace('T', '').split('.')[0];
+  const jobId = `codex-index-${sanitized}`;
+  const totalSizeBytes = scrolls.reduce((sum, scroll) => sum + scroll.sizeBytes, 0);
+
+  const index = {
+    meta: {
+      generatedAt,
+      jobId,
+      scrollCount: scrolls.length,
+      totalSizeBytes,
+    },
+    statuses,
+    scrolls,
+  };
+
+  const outPath = path.resolve(root, 'docs', 'codex-index.json');
+  await writeFileEnsured(outPath, JSON.stringify(index, null, 2) + '\n');
+  console.log(`🧭 Codex index generated → ${path.relative(root, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error('Codex index generation failed.', err);
+  process.exitCode = 1;
+});

--- a/scripts/codex/notify.ts
+++ b/scripts/codex/notify.ts
@@ -1,0 +1,89 @@
+import { glyphForStatus, readCodexIndex } from './common';
+
+type WebhookResult = {
+  url: string;
+  ok: boolean;
+  status: number;
+  statusText: string;
+};
+
+function buildStatusLine(statuses: Record<string, number>): string {
+  const parts = Object.entries(statuses)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([status, count]) => `${glyphForStatus(status)} ${status}: ${count}`);
+  return parts.join(' | ');
+}
+
+function buildPayload(index: Awaited<ReturnType<typeof readCodexIndex>>) {
+  const statusLine = buildStatusLine(index.statuses) || 'No scrolls registered.';
+  const headline = `Codex ritual ${index.meta.jobId}`;
+  const summary = `${headline}\n${statusLine}\nScrolls: ${index.meta.scrollCount} • Total Size: ${index.meta.totalSizeBytes} B`;
+  return {
+    text: summary,
+    codexMeta: {
+      jobId: index.meta.jobId,
+      generatedAt: index.meta.generatedAt,
+      scrollCount: index.meta.scrollCount,
+      totalSizeBytes: index.meta.totalSizeBytes,
+      statuses: index.statuses,
+    },
+  };
+}
+
+async function postWebhook(url: string, payload: unknown): Promise<WebhookResult> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return { url, ok: response.ok, status: response.status, statusText: response.statusText };
+}
+
+async function main() {
+  const index = await readCodexIndex();
+  const payload = buildPayload(index);
+  const dryRunValue = String(process.env.DRY_RUN ?? '').toLowerCase();
+  const dryRun = ['true', '1', 'yes'].includes(dryRunValue);
+
+  const slackUrl = process.env.SLACK_WEBHOOK_URL;
+  const studioShareUrl = process.env.STUDIOSHARE_WEBHOOK_URL;
+  const targets = [
+    slackUrl && { name: 'Slack', url: slackUrl },
+    studioShareUrl && { name: 'StudioShare', url: studioShareUrl },
+  ].filter((entry): entry is { name: string; url: string } => Boolean(entry && entry.url));
+
+  if (!targets.length) {
+    console.log('ℹ️  No notifier targets configured (set SLACK_WEBHOOK_URL or STUDIOSHARE_WEBHOOK_URL).');
+  }
+
+  if (dryRun) {
+    console.log('🔍 DRY_RUN active — payload preview only.');
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const results: WebhookResult[] = [];
+  for (const target of targets) {
+    try {
+      const result = await postWebhook(target.url, payload);
+      results.push(result);
+      if (result.ok) {
+        console.log(`📡 Notified ${target.name} (${result.status} ${result.statusText}).`);
+      } else {
+        console.error(`⚠️  ${target.name} notification failed (${result.status} ${result.statusText}).`);
+      }
+    } catch (err) {
+      console.error(`⚠️  ${target.name} notification error:`, err);
+    }
+  }
+
+  if (!results.length && targets.length) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error('Codex notification failed.');
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/scripts/codex/render-status.ts
+++ b/scripts/codex/render-status.ts
@@ -1,0 +1,95 @@
+import path from 'path';
+
+import { glyphForStatus, readCodexIndex, writeFileEnsured } from './common';
+
+function humanizeStatus(status: string): string {
+  return status
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
+function truncate(text: string, max = 160): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'kB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const formatted = unitIndex === 0 ? `${value} ${units[unitIndex]}` : `${value.toFixed(1)} ${units[unitIndex]}`;
+  return `${formatted} (${bytes} B)`;
+}
+
+async function main() {
+  const root = process.cwd();
+  const index = await readCodexIndex(root);
+  const docDir = path.resolve(root, 'docs');
+  const outPath = path.join(docDir, 'codex-status.md');
+
+  const statusEntries = Object.entries(index.statuses).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`jobId: ${index.meta.jobId}`);
+  lines.push(`generatedAt: ${index.meta.generatedAt}`);
+  lines.push(`scrollCount: ${index.meta.scrollCount}`);
+  lines.push(`totalSizeBytes: ${index.meta.totalSizeBytes}`);
+  lines.push('---');
+  lines.push('');
+  lines.push('# Codex Status Ledger');
+  lines.push('');
+  lines.push('Glyph ledger for Codex scroll exports.');
+  lines.push('');
+  lines.push('| Glyph | Status | Count |');
+  lines.push('| :---- | :----- | ----: |');
+  for (const [status, count] of statusEntries) {
+    const glyph = glyphForStatus(status);
+    lines.push(`| ${glyph} | ${escapeCell(humanizeStatus(status))} | ${count} |`);
+  }
+  lines.push('');
+  lines.push('## Scroll Directory');
+  lines.push('');
+  lines.push('| Glyph | Scroll | Status | Version | Last Updated | Owners | Size | Excerpt |');
+  lines.push('| :---- | :----- | :----- | :------ | :----------- | :----- | ----: | :------ |');
+
+  for (const scroll of index.scrolls) {
+    const glyph = glyphForStatus(scroll.status);
+    const statusLabel = humanizeStatus(scroll.status);
+    const owners = scroll.owners.length ? scroll.owners.map(escapeCell).join('<br>') : '—';
+    const relativeScroll = path
+      .relative(path.dirname(outPath), path.resolve(root, scroll.path))
+      .replace(/\\\\/g, '/')
+      .replace(/\\/g, '/');
+    const link = `[${escapeCell(scroll.title)}](${relativeScroll})`;
+    const size = escapeCell(formatBytes(scroll.sizeBytes));
+    const excerpt = scroll.excerpt ? escapeCell(truncate(scroll.excerpt)) : '—';
+    const version = scroll.version ? escapeCell(scroll.version) : '—';
+    const updated = scroll.lastUpdated ? escapeCell(scroll.lastUpdated) : '—';
+
+    lines.push(
+      `| ${glyph} | ${link} | ${escapeCell(statusLabel)} | ${version} | ${updated} | ${owners} | ${size} | ${excerpt} |`
+    );
+  }
+
+  lines.push('');
+  lines.push('<!-- Generated via npm run codex:render -->');
+
+  await writeFileEnsured(outPath, `${lines.join('\n')}\n`);
+  console.log(`🪶 Codex status rendered → ${path.relative(root, outPath)}`);
+}
+
+main().catch((err) => {
+  console.error('Codex status render failed.', err);
+  process.exitCode = 1;
+});

--- a/scripts/codex/update-status-snapshot.ts
+++ b/scripts/codex/update-status-snapshot.ts
@@ -1,0 +1,24 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function main() {
+  const root = process.cwd();
+  const sourcePath = path.resolve(root, 'docs', 'codex-status.md');
+  const destPath = path.resolve(root, 'fixtures', 'expected-codex-status.md');
+
+  const contents = await fs.readFile(sourcePath, 'utf8').catch((err) => {
+    throw new Error(
+      `Unable to read ${sourcePath}: ${(err as Error).message}. Render the status first with npm run codex:render.`
+    );
+  });
+
+  await fs.mkdir(path.dirname(destPath), { recursive: true });
+  await fs.writeFile(destPath, contents);
+  console.log(`📸 Snapshot updated → ${path.relative(root, destPath)}`);
+}
+
+main().catch((err) => {
+  console.error('Snapshot update failed.');
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/scripts/codex/validate-index.ts
+++ b/scripts/codex/validate-index.ts
@@ -1,0 +1,120 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { z } from 'zod';
+
+import { CodexIndex, readCodexIndex } from './common';
+
+const ScrollSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  status: z.string().min(1),
+  version: z.string().min(1),
+  lastUpdated: z.string().min(1),
+  owners: z.array(z.string()),
+  links: z.array(z.object({ label: z.string(), url: z.string() })),
+  path: z.string().min(1),
+  excerpt: z.string(),
+  sizeBytes: z.number().int().nonnegative(),
+});
+
+const CodexIndexSchema = z.object({
+  meta: z.object({
+    generatedAt: z
+      .string()
+      .min(1)
+      .refine((value) => !Number.isNaN(Date.parse(value)), 'generatedAt must be an ISO timestamp'),
+    jobId: z.string().min(1),
+    scrollCount: z.number().int().nonnegative(),
+    totalSizeBytes: z.number().int().nonnegative(),
+  }),
+  statuses: z.record(z.number().int().nonnegative()),
+  scrolls: z.array(ScrollSchema),
+});
+
+function assertIndexShape(index: CodexIndex) {
+  const parsed = CodexIndexSchema.safeParse(index);
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues.map((issue) => issue.message).join('\n'));
+  }
+}
+
+async function ensureFilesMatch(index: CodexIndex) {
+  const root = process.cwd();
+  const missing: string[] = [];
+  const mismatchedSizes: string[] = [];
+
+  for (const scroll of index.scrolls) {
+    const abs = path.resolve(root, scroll.path);
+    try {
+      const content = await fs.readFile(abs, 'utf8');
+      const actualSize = Buffer.byteLength(content, 'utf8');
+      if (actualSize !== scroll.sizeBytes) {
+        mismatchedSizes.push(`${scroll.id} (${scroll.path}) expected ${scroll.sizeBytes} bytes, found ${actualSize}`);
+      }
+    } catch (err) {
+      missing.push(`${scroll.id} (${scroll.path}): ${(err as Error).message}`);
+    }
+  }
+
+  if (missing.length) {
+    throw new Error(['Missing scroll files:', ...missing].join('\n'));
+  }
+  if (mismatchedSizes.length) {
+    throw new Error(['Size drift detected:', ...mismatchedSizes].join('\n'));
+  }
+}
+
+function ensureCounts(index: CodexIndex) {
+  if (index.meta.scrollCount !== index.scrolls.length) {
+    throw new Error(
+      `scrollCount ${index.meta.scrollCount} does not match entries ${index.scrolls.length}`
+    );
+  }
+
+  const counts = index.scrolls.reduce<Record<string, number>>((acc, scroll) => {
+    const key = scroll.status.toLowerCase();
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const statusKeys = new Set([...Object.keys(counts), ...Object.keys(index.statuses)]);
+  const discrepancies: string[] = [];
+  for (const key of statusKeys) {
+    if ((counts[key] ?? 0) !== (index.statuses[key] ?? 0)) {
+      discrepancies.push(`${key}: expected ${counts[key] ?? 0}, found ${index.statuses[key] ?? 0}`);
+    }
+  }
+  if (discrepancies.length) {
+    throw new Error(['Status count mismatch detected:', ...discrepancies].join('\n'));
+  }
+
+  const totalStatuses = Object.values(index.statuses).reduce((sum, value) => sum + value, 0);
+  if (totalStatuses !== index.scrolls.length) {
+    throw new Error(
+      `Status totals (${totalStatuses}) do not equal scroll count (${index.scrolls.length})`
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const scroll of index.scrolls) {
+    if (ids.has(scroll.id)) {
+      throw new Error(`Duplicate scroll id detected: ${scroll.id}`);
+    }
+    ids.add(scroll.id);
+  }
+}
+
+async function main() {
+  const index = await readCodexIndex();
+  assertIndexShape(index);
+  ensureCounts(index);
+  await ensureFilesMatch(index);
+  console.log(`✅ Codex index validated (${index.scrolls.length} scrolls, job ${index.meta.jobId}).`);
+}
+
+main().catch((err) => {
+  console.error('Codex index validation failed.');
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add npm scripts that orchestrate codex generation, rendering, validation, guard, and smoke loops
- implement codex index/status builders with snapshot + notification helpers and check them into docs/fixtures
- introduce TypeScript tooling config and ignore files for the new workflow

## Testing
- npm run codex:ritual
- npm run codex:guard
- npm run smoke

------
https://chatgpt.com/codex/tasks/task_b_68f6c9e8b278832e8815fc5cd36fff56