### PR TITLE
Add factorial helper with Jest coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+- Added factorial utility with Jest coverage for regression protection.
 ## v1.4.5 — Remix Scheduler (2025-10-19)
 
 ### Codex Helpers

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,17 @@
+const { factorial } = require('../utils');
+
+describe('factorial', () => {
+  it('returns 1 for the base cases 0 and 1', () => {
+    expect(factorial(0)).toBe(1);
+    expect(factorial(1)).toBe(1);
+  });
+
+  it('computes factorial for positive integers', () => {
+    expect(factorial(5)).toBe(120);
+    expect(factorial(7)).toBe(5040);
+  });
+
+  it('throws on negative input', () => {
+    expect(() => factorial(-3)).toThrow('Factorial not defined for negative numbers');
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,22 @@
+function factorial(n) {
+  if (!Number.isInteger(n)) {
+    throw new TypeError('Factorial only defined for integers');
+  }
+
+  if (n < 0) {
+    throw new Error('Factorial not defined for negative numbers');
+  }
+
+  if (n === 0 || n === 1) {
+    return 1;
+  }
+
+  let result = 1;
+  for (let i = 2; i <= n; i += 1) {
+    result *= i;
+  }
+
+  return result;
+}
+
+module.exports = { factorial };


### PR DESCRIPTION
## Summary
- add a factorial utility that guards invalid inputs and matches the existing error message
- add a Jest test suite covering base, positive, and negative-input behaviour
- note the addition in the draft changelog for ritual traceability

## Testing
- npm test *(fails: repository has no package.json / Jest wiring yet)*

------
https://chatgpt.com/codex/tasks/task_b_68f6c8b9e62c832e89d389ae0c50139e