### PR TITLE
Fix Codex review workflow YAML indentation

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -66,11 +66,7 @@ jobs:
             exit 1
           fi
 
-          esc_diff=$(python3 - <<'PY'
-import json
-print(json.dumps(open("pr.diff","r",encoding="utf-8",errors="ignore").read()))
-PY
-)
+          esc_diff=$(python3 -c "import json;print(json.dumps(open('pr.diff','r',encoding='utf-8',errors='ignore').read()))")
 
           body=$(jq -n \
             --arg repo "${{ github.repository }}" \


### PR DESCRIPTION
## Summary
- replace the heredoc-based Python snippet with a single-line command to avoid indentation-sensitive YAML
- restore the Codex review workflow so it parses the diff without triggering syntax errors

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68f54f5f2884832e90bd90f7fa0251a6