### PR TITLE
Update Codex review workflow checkout reference

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -26,7 +26,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Checkout dispatch ref


### PR DESCRIPTION
## Summary
- ensure the Codex review workflow checks out the contributor repository
- use the pull request head ref with full history for resilience

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68f5263436cc832e9d2f0cf6069cdba0