### PR TITLE
Add Codex Cloud Ritual scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Artifacts & Usability
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
+- New Codex Cloud Ritual scroll documenting delegation flows, security gates, and lineage stewardship.
 
 ### DevOps
 - `/api/health` instance/env guard.

--- a/scrolls/codex-cloud.md
+++ b/scrolls/codex-cloud.md
@@ -1,0 +1,31 @@
+# Codex Scroll: Codex Cloud Ritual
+id: scroll-codex-cloud
+status: draft
+version: 0.1.0
+last_updated: 2024-01-20
+
+## Invocation
+- Navigate to `chatgpt.com/codex` and link your GitHub lineage to grant Codex repository access.
+- Ensure Codex has an environment descriptor when spawning cloud sandboxes; reuse named environments for repeatable rituals.
+- Confirm your ChatGPT plan (Plus, Pro, Team, Edu, or Enterprise) is active; some Enterprise hives may require admin blessing before access unlocks.
+
+## Delegation Modes
+- **Ask Mode:** summon analysis without mutations—architecture briefings, refactor drafts, and flow diagrams.
+- **Code Mode:** authorize Codex to reshape branches, execute suites, and stage PRs.
+- Codex provisions per-task sandboxes, enabling parallel background work across devices (web, IDE extension, iOS Codex tab, or @codex mentions in GitHub).
+- CLI delegation is forthcoming; log ritual notes in StudioShare until the CLI shrine opens.
+
+## Environment Weaving
+- Provide repository scope and dependency manifests so Codex can hydrate containers with required runtimes.
+- Prefer documented scripts (`npm run <ritual>`) over ad-hoc commands; Codex honors existing smoke harnesses and deployment webhooks.
+- Track operational metadata (jobId, sizeBytes, status) for CodexReplay overlays and badge updates whenever artifacts shift.
+
+## Security Gates
+- Accounts using email/password must enable multi-factor authentication before Codex opens the workshop.
+- Social logins (Google, Microsoft, Apple) should still activate MFA via their providers for full warding.
+- SSO access inherits organization-level MFA enforcement; coordinate with the SSO steward if rites are incomplete.
+
+## Lineage Stewardship
+- Update changelog entries, Codex index pointers, and StudioShare threads after each refinement.
+- If a prompt falters, propose micro-patches with precise filenames and code hunks—never vague counsel.
+- Treat every annotation like a scroll entry: clear, modular, and teachable.


### PR DESCRIPTION
## Summary
- add a Codex Cloud Ritual scroll capturing delegation flows, environment setup, and security requirements
- note the new scroll in the draft changelog under Artifacts & Usability

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f501578d5c832eb41262f7913506b2