### PR TITLE
Add LM Studio bridge scroll and extend ritual metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@
 ### Artifacts & Usability
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
+- New "LM Studio Bridge" scroll documenting SDK, MCP manifest, and CLI rituals.
 
 ### DevOps
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+- Netlify ritual endpoints now capture `jobId` + `sizeBytes` metadata for CodexReplay overlays and Slack beacons.

--- a/netlify/functions/ritual-metrics.ts
+++ b/netlify/functions/ritual-metrics.ts
@@ -5,20 +5,97 @@ const STORE = 'beehive_badge';
 const HISTORY_KEY = 'history';
 const VERSION = 1;
 
-// keep payloads compact and bounded
-function pruneHistory(list: any[], max = 1000, maxDays = 90) {
+type MetricEntry = {
+  timestamp: string;
+  status: 'ok' | 'fail';
+  actor: string | null;
+  jobId: string | null;
+  sizeBytes: number | null;
+  artifactUrl: string | null;
+  notes: string | null;
+};
+
+function parseSizeBytes(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.max(0, Math.round(value));
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return Math.max(0, Math.round(parsed));
+      }
+    }
+  }
+  return null;
+}
+
+function toMetricEntry(raw: any): MetricEntry | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const status: 'ok' | 'fail' = raw.status === 'fail' ? 'fail' : 'ok';
+
+  const timestampCandidate =
+    typeof raw.timestamp === 'string' && raw.timestamp
+      ? raw.timestamp
+      : typeof raw.updatedAt === 'string' && raw.updatedAt
+      ? raw.updatedAt
+      : null;
+  if (!timestampCandidate) return null;
+
+  const actor =
+    typeof raw.actor === 'string' && raw.actor.trim() ? raw.actor.trim() : null;
+  const jobId =
+    typeof raw.jobId === 'string' && raw.jobId.trim() ? raw.jobId.trim() : null;
+  const artifactUrlCandidate = raw.artifactUrl ?? raw.artifact_url;
+  const artifactUrl =
+    typeof artifactUrlCandidate === 'string' && artifactUrlCandidate.trim()
+      ? artifactUrlCandidate.trim()
+      : null;
+  const notes =
+    typeof raw.notes === 'string' && raw.notes.trim() ? raw.notes.trim() : null;
+  const sizeCandidate = raw.sizeBytes ?? raw.size_bytes;
+  const sizeBytes = parseSizeBytes(sizeCandidate);
+
+  return {
+    timestamp: timestampCandidate,
+    status,
+    actor,
+    jobId,
+    sizeBytes,
+    artifactUrl,
+    notes,
+  };
+}
+
+function pruneHistory<T extends { timestamp: string }>(list: T[], max = 1000, maxDays = 90) {
   const cutoff = Date.now() - maxDays * 86_400_000;
   return (list || [])
-    .filter((e) => {
-      const t = new Date(e.timestamp).getTime();
+    .filter((entry) => {
+      const t = new Date(entry.timestamp).getTime();
       return Number.isFinite(t) && t > cutoff;
     })
     .slice(-max);
 }
 
+function summarize(entry: MetricEntry) {
+  return {
+    timestamp: entry.timestamp,
+    status: entry.status,
+    actor: entry.actor,
+    jobId: entry.jobId,
+    sizeBytes: entry.sizeBytes,
+    artifactUrl: entry.artifactUrl,
+    notes: entry.notes,
+  };
+}
+
 export const handler: Handler = async () => {
   const store = getStore(STORE);
-  const history = ((await store.get(HISTORY_KEY, { type: 'json' })) as any[]) || [];
+  const rawHistory = ((await store.get(HISTORY_KEY, { type: 'json' })) as any[]) || [];
+  const history = rawHistory
+    .map((entry) => toMetricEntry(entry))
+    .filter((entry): entry is MetricEntry => entry !== null);
 
   const now = Date.now();
   const lastDay = now - 86_400_000;
@@ -31,19 +108,39 @@ export const handler: Handler = async () => {
   const last24 = recent.length;
   const last24Ok = recent.filter((e) => e.status === 'ok').length;
 
+  const bytesTotal = history.reduce((sum, entry) => sum + (entry.sizeBytes ?? 0), 0);
+  const bytesLast24 = recent.reduce((sum, entry) => sum + (entry.sizeBytes ?? 0), 0);
+
+  const current = total ? history[total - 1] : null;
+  const currentPayload = current ? summarize(current) : null;
+  const overlay = current
+    ? {
+        status: current.status,
+        jobId: current.jobId,
+        sizeBytes: current.sizeBytes,
+        artifactUrl: current.artifactUrl,
+        timestamp: current.timestamp,
+        actor: current.actor,
+        notes: current.notes,
+      }
+    : null;
+
   const payload = {
     version: VERSION,
-    current: total ? history[total - 1] : null,
+    current: currentPayload,
     statistics: {
       total,
       ok,
       fail,
       success_ratio: total ? (ok / total) * 100 : null,
+      bytes_total: bytesTotal || null,
+      bytes_last_24h: bytesLast24 || null,
     },
     uptime: {
       last_24h: last24 ? (last24Ok / last24) * 100 : null,
     },
-    recent_history: pruneHistory(history, 10),
+    replay_overlay: overlay,
+    recent_history: pruneHistory(history, 10).map(summarize),
   };
 
   return {

--- a/scrolls/lmstudio-bridge.md
+++ b/scrolls/lmstudio-bridge.md
@@ -1,0 +1,98 @@
+# Codex Scroll: LM Studio Bridge
+id: scroll-lmstudio-bridge
+status: draft
+version: 0.1.0
+last_updated: 2025-10-15
+
+## Setup Ritual
+- `npm install @lmstudio/sdk`
+- Ensure LM Studio desktop is running with the OpenAI-compatible server enabled.
+
+## Node Ritual — `@lmstudio/sdk`
+```ts
+import { Chat, LMStudioClient, tool } from "@lmstudio/sdk";
+import { existsSync } from "fs";
+import { writeFile } from "fs/promises";
+import { createInterface } from "readline/promises";
+import { z } from "zod";
+ 
+const rl = createInterface({ input: process.stdin, output: process.stdout });
+const client = new LMStudioClient();
+const model = await client.llm.model("openai/gpt-oss-20b");
+const chat = Chat.empty();
+ 
+const createFileTool = tool({
+  name: "createFile",
+  description: "Create a file with the given name and content.",
+  parameters: { name: z.string(), content: z.string() },
+  implementation: async ({ name, content }) => {
+    if (existsSync(name)) {
+      return "Error: File already exists.";
+    }
+    await writeFile(name, content, "utf-8");
+    return "File created.";
+  },
+});
+ 
+while (true) {
+  const input = await rl.question("User: ");
+  chat.append("user", input);
+ 
+  process.stdout.write("Assistant: ");
+  await model.act(chat, [createFileTool], {
+    onMessage: (message) => chat.append(message),
+    onPredictionFragment: ({ content }) => {
+      process.stdout.write(content);
+    },
+  });
+  process.stdout.write("\n");
+}
+```
+
+## Local MCP Manifest
+Place the following in `~/.lmstudio/mcp.json` to activate the OpenAI bridge:
+```json
+{
+  "servers": [
+    {
+      "command": "python",
+      "args": ["-m", "openai_mcp_server"],
+      "env": {
+        "OPENAI_API_KEY": "not-needed",
+        "OPENAI_BASE_URL": "http://localhost:1234/v1"
+      }
+    }
+  ]
+}
+```
+
+## Python Bridge Invocation
+```python
+from openai import OpenAI
+ 
+client = OpenAI(
+    base_url="http://localhost:1234/v1",
+    api_key="not-needed"
+)
+ 
+result = client.chat.completions.create(
+    model="openai/gpt-oss-20b",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain what MXFP4 quantization is."}
+    ]
+)
+ 
+print(result.choices[0].message.content)
+```
+
+## CLI Rituals
+```bash
+lms chat openai/gpt-oss-20b
+lms load openai/gpt-oss-20b
+lms get openai/gpt-oss-20b
+# swap `20b` with `120b` for the larger release
+```
+
+## Replay Metadata Handshake
+The Netlify `ritual-ping` + `ritual-metrics` endpoints now emit `jobId`, `sizeBytes`, `artifactUrl`, and status payloads for CodexReplay overlays—keep these fields flowing when triggering exports.


### PR DESCRIPTION
## Summary
- document the LM Studio bridge ritual with SDK usage, MCP manifest, and CLI cues
- extend ritual ping + metrics Netlify functions to emit jobId/sizeBytes/artifact overlays for CodexReplay
- record the lineage update in the changelog

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68f4ffb2fc90832e9748d06ff5d4d409