### PR TITLE
Enhance ritual agent metadata payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,10 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+
+## [1.3.0] — Codex Agent Runner
+
+- Added `ritual-agent.ts` Netlify Function powered by OpenAI Codex.
+- Accepts POST requests with `prompt` field and returns Codex + metadata payloads for observability overlays.
+- Linked function from the homepage directory and repository README with sample replay payload.
+- Documented environment expectations for Netlify deploys.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# BeeHive Ritual Stack
+
+BeeHive orchestrates creative rituals across agents, telemetry, and observability. This repository contains the Netlify runner,
+Supabase schemas, and front-end surfaces for the swarm.
+
+## Codex Agent Runner
+
+Invoke the OpenAI-backed ritual agent via Netlify Functions:
+
+```bash
+curl -sS -X POST https://<site>.netlify.app/.netlify/functions/ritual-agent \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Summarize the BeeHive ritual stack"}'
+```
+
+Typical response payload (fields are stable for CodexReplay overlays):
+
+```json
+{
+  "ok": true,
+  "requestId": "7f3d0...",
+  "output": "...",
+  "metadata": {
+    "jobId": "chatcmpl-...",
+    "model": "gpt-4o-mini",
+    "created": 1718132435,
+    "usage": { "prompt_tokens": 24, "completion_tokens": 98, "total_tokens": 122 },
+    "sizeBytes": 128,
+    "status": "stop"
+  }
+}
+```
+
+Set the required environment variable before deploying:
+
+```bash
+netlify env:set OPENAI_API_KEY "<your-secret-key>"
+```
+
+Override the default `gpt-4o-mini` selection by defining `OPENAI_MODEL`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,4 @@
 
 [functions]
   directory = "netlify/functions"
+  node_bundler = "esbuild"

--- a/netlify/functions/ritual-agent.ts
+++ b/netlify/functions/ritual-agent.ts
@@ -1,0 +1,91 @@
+import type { Handler } from "@netlify/functions";
+import { randomUUID } from "node:crypto";
+import OpenAI from "openai";
+
+const MODEL = process.env.OPENAI_MODEL ?? "gpt-4o-mini";
+
+let cachedClient: OpenAI | null = null;
+
+function getClient(): OpenAI {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing OPENAI_API_KEY");
+  }
+
+  if (!cachedClient) {
+    cachedClient = new OpenAI({ apiKey });
+  }
+
+  return cachedClient;
+}
+
+function json(body: Record<string, unknown>, statusCode = 200) {
+  return {
+    statusCode,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+export const handler: Handler = async (event) => {
+  const requestId = randomUUID();
+
+  if (event.httpMethod !== "POST") {
+    return json({ ok: false, error: "Method Not Allowed", requestId }, 405);
+  }
+
+  let prompt = "";
+  if (event.body) {
+    try {
+      const body = JSON.parse(event.body) as Record<string, unknown>;
+      const candidate = body.prompt;
+      if (typeof candidate === "string") {
+        prompt = candidate.trim();
+      }
+    } catch {
+      // ignore malformed JSON and fall through to validation
+    }
+  }
+
+  if (!prompt) {
+    return json({ ok: false, error: "Missing prompt", requestId }, 400);
+  }
+
+  let client: OpenAI;
+  try {
+    client = getClient();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : `OpenAI client error: ${String(error)}`;
+    return json({ ok: false, error: message, requestId }, 500);
+  }
+
+  const promptBytes = Buffer.byteLength(prompt, "utf8");
+
+  try {
+    const completion = await client.chat.completions.create({
+      model: MODEL,
+      messages: [{ role: "user", content: prompt }],
+    });
+
+    const output = completion.choices?.[0]?.message?.content ?? "";
+
+    return json({
+      ok: true,
+      requestId,
+      output,
+      metadata: {
+        jobId: completion.id,
+        model: completion.model,
+        created: completion.created,
+        usage: completion.usage,
+        sizeBytes: promptBytes,
+        status: completion.choices?.[0]?.finish_reason ?? "unknown",
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : `OpenAI request failed: ${String(error)}`;
+    return json({ ok: false, error: message, requestId }, 500);
+  }
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { CODEX_INSTANCE } from "@/lib/instance";
+
+const functions = [
+  { href: "/.netlify/functions/deploy-notify", label: "deploy-notify (POST)" },
+  { href: "/.netlify/functions/ritual-agent", label: "ritual-agent (POST)" },
+];
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-amber-50 via-white to-amber-100">
+      <section className="mx-auto flex max-w-3xl flex-col gap-8 px-6 py-16">
+        <header className="space-y-2 text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-amber-500">BeeHive</p>
+          <h1 className="text-4xl font-semibold text-gray-900">Ritual Stack Directory</h1>
+          <p className="text-sm text-gray-500">
+            Instance: <span className="font-mono text-gray-700">{CODEX_INSTANCE}</span>
+          </p>
+        </header>
+
+        <section className="rounded-3xl border border-amber-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-gray-900">Netlify Functions</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Each endpoint responds with observability metadata to keep the swarm in sync.
+          </p>
+          <ul className="mt-4 space-y-2 text-sm text-amber-700">
+            {functions.map((fn) => (
+              <li key={fn.href}>
+                <Link className="hover:underline" href={fn.href}>
+                  {fn.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 rounded-lg bg-amber-50 p-4 text-xs text-amber-800">
+            The ritual agent returns <span className="font-semibold">requestId</span>,
+            <span className="font-semibold"> jobId</span>, and <span className="font-semibold">sizeBytes</span>
+            for CodexReplay overlays. Capture these fields to stitch swarm lineage.
+          </p>
+        </section>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- upgrade the ritual agent Netlify function to use the latest OpenAI client and emit request metadata for CodexReplay overlays
- document the enriched response contract and default model in the README and landing page copy
- align the changelog entry with the metadata-focused behaviour of the function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f3a03544dc832e8292a33a30e2fab5