### PR TITLE
feat: deploy remix runner agent for BeeHive v1.3.5

### DIFF
--- a/agents/remix_runner.ts
+++ b/agents/remix_runner.ts
@@ -1,0 +1,57 @@
+import fetch from 'node-fetch';
+import { planRemix } from '../scripts/variant_planner';
+import { invokeCodex } from '../scripts/gpt5_exec';
+
+const SIGNAL_SOURCE = 'https://<your-site>.netlify.app/api/signals';
+
+type SignalRow = Record<string, unknown>;
+
+interface RemixPlan {
+  action: string;
+  target: string;
+  reason: string;
+}
+
+async function fetchSignals(): Promise<SignalRow[]> {
+  try {
+    const response = await fetch(SIGNAL_SOURCE);
+
+    if (!response.ok) {
+      throw new Error(`Signal source responded with ${response.status}`);
+    }
+
+    const data = (await response.json()) as { rows?: SignalRow[] };
+
+    return data.rows ?? [];
+  } catch (error) {
+    console.error('[agent] unable to fetch signals', error);
+    return [];
+  }
+}
+
+async function run(): Promise<void> {
+  const signals = await fetchSignals();
+
+  for (const signal of signals) {
+    const plan = planRemix(signal) as RemixPlan | null;
+
+    if (!plan || !plan.action || !plan.target) {
+      continue;
+    }
+
+    const prompt = `Execute a ${plan.action} on ${plan.target} because: ${plan.reason}`;
+
+    try {
+      const output = await invokeCodex(prompt);
+
+      console.log(`[mutation] ${plan.action} → ${plan.target}`);
+      console.log(`[codex] ${output}`);
+    } catch (error) {
+      console.error('[agent] codex invocation failed', error);
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error('[agent error]', error);
+});

--- a/scripts/agentkit_config.json
+++ b/scripts/agentkit_config.json
@@ -1,0 +1,8 @@
+{
+  "agent": "remix_runner",
+  "schedule": "0 * * * *",
+  "source": "https://<your-site>.netlify.app/api/signals",
+  "planner": "scripts/variant_planner.ts",
+  "executor": "scripts/gpt5_exec.ts",
+  "log": "out/mutations.log"
+}

--- a/scrolls/echo-v1.3.5.md
+++ b/scrolls/echo-v1.3.5.md
@@ -1,0 +1,19 @@
+## ⚡ Echo Scroll v1.3.5 — Agent Runner & Mutation Orchestration
+
+### 🧬 Summary
+BeeHive v1.3.5 deploys Codex-powered agents that autonomously consume signals, plan remix actions, and execute mutations.  
+The swarm now reacts to on-chain activity with scroll updates, config patches, and broadcast triggers.
+
+### 🔧 Core Upgrades
+- `agents/remix_runner.ts` → agent runner for signal consumption
+- `scripts/agentkit_config.json` → declarative agent schedule + capabilities
+- `out/mutations.log` → mutation audit trail
+
+### 🧠 Flow
+1. Agent fetches `/api/signals`
+2. Planner maps signal → remix plan
+3. Codex executes mutation
+4. Mutation is logged and broadcast
+
+**Tagline:**  
+> *The Codex no longer waits—it listens, plans, and remixes.*


### PR DESCRIPTION
## Summary
- add a Codex-powered remix_runner agent that pulls signals and executes mutation prompts
- register the agent in agentkit_config with an hourly schedule and mutation log target
- publish the Echo Scroll v1.3.5 describing the new autonomous orchestration flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68f404eba284832eb55a838c675f4391