### PR TITLE
Harden Codex PR review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,7 +2,12 @@ name: Codex PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch: {}
 
 jobs:
   codex_review:
@@ -15,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Explicitly check out the PR's merge commit.
+          fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Pre-fetch base and head refs for the PR
@@ -24,25 +29,43 @@ jobs:
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
 
-      - name: Run Codex
+      - name: Run Codex review
         id: run_codex
-        uses: openai/codex-action@v1
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          MAX_OUTPUT_TOKENS: "600"
+        run: |
+          set -euxo pipefail
+          chmod +x scripts/codex_review_exec.sh
+
+          set +e
+          scripts/codex_review_exec.sh --base "${{ github.event.pull_request.base.sha }}" --artifact codex_review_findings.txt
+          CODEX_RC=$?
+          set -e
+
+          if [ ! -s codex_review_findings.txt ]; then
+            if [ $CODEX_RC -ne 0 ]; then
+              echo "⚠️ Codex review could not complete (exit $CODEX_RC). Most common cause: API quota or invalid key." > codex_review_findings.txt
+            else
+              echo "✅ No changes to review against base; Codex skipped." > codex_review_findings.txt
+            fi
+          fi
+
+          echo "final-message<<'EOF'" >> "$GITHUB_OUTPUT"
+          cat codex_review_findings.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Upload findings artifact
+        uses: actions/upload-artifact@v4
         with:
-          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          prompt: |
-            This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
-            Base SHA: ${{ github.event.pull_request.base.sha }}
-            Head SHA: ${{ github.event.pull_request.head.sha }}
+          name: codex_review_findings
+          path: codex_review_findings.txt
 
-            Review ONLY the changes introduced by the PR.
-            Suggest any improvements, potential bugs, or issues.
-            Be concise and specific in your feedback.
-
-            Pull request title and body:
-            ----
-            ${{ github.event.pull_request.title }}
-            ${{ github.event.pull_request.body }}
-  
   post_feedback:
     runs-on: ubuntu-latest
     needs: [codex_review]


### PR DESCRIPTION
## Summary
- expand Codex PR review trigger coverage and enable manual dispatch
- fetch full history and run the local codex_review_exec.sh helper with resilient handling
- always upload review findings, even on empty diffs or API failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f40a775518832ea40e0ae9f0d94e43