### PR TITLE
fix(ci): guard codex review workflow on forks

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   codex_review:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       pull-requests: write
@@ -46,7 +47,7 @@ jobs:
   post_feedback:
     runs-on: ubuntu-latest
     needs: [codex_review]
-    if: needs.codex_review.outputs.final_message != ''
+    if: needs.codex_review.result == 'success' && needs.codex_review.outputs.final_message != ''
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- skip the Codex review job when the pull request comes from a fork where repository secrets are unavailable
- ensure the feedback posting job only runs after a successful Codex review with a generated message

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68f4f6bf0c50832eb4b503435b62ee4d