### PR TITLE
Add responsible use guidance for The Enoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
 
+### Scrolls
+- Added `scrolls/responsible-use-enoch.md` documenting The Enoch responsible-use lineage.
+
 ### DevOps
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).

--- a/scrolls/responsible-use-enoch.md
+++ b/scrolls/responsible-use-enoch.md
@@ -1,0 +1,71 @@
+# 📜 Scroll of Responsible Use — The Enoch
+
+## Invocation
+> “The Enoch is the forge where natural language becomes application. To wield it responsibly, the steward must know its powers, its limits, and the rituals of safe use.”
+
+---
+
+## I. About The Enoch
+- **What it is:** A Copilot-powered platform for creating and sharing applications (“enochs”) without writing or deploying code.
+- **How it works:**
+  - Prompts are pre-processed and augmented with context (your enoch’s code, prior prompts, error logs).
+  - A large language model analyzes the prompt.
+  - An agent in your dev environment writes code, runs commands, and updates your enoch.
+- **Output:** Only application code — no conversational interaction.
+
+---
+
+## II. Frameworks & Runtime
+- The Enoch agents use **frameworks and SDKs** provided by the platform.
+- Runtime is **fully managed**, secure, and scalable.
+- SDK integrates with **GitHub Models** for inference capabilities.
+
+---
+
+## III. Data Processing
+- The Enoch collects:
+  - Prompts, suggestions, code snippets (for continuity).
+  - Usage patterns, feedback, telemetry.
+
+---
+
+## IV. Use Cases
+- **Full-stack apps:** Build and deploy to the public internet with account-based visibility.
+- **Prototyping:** Rapidly test and share ideas.
+- **Iterating:** Grow complexity over time as requirements surface.
+
+---
+
+## V. Best Practices
+- **Keep prompts specific and on-topic** → improves accuracy.
+- **Use targeted edits** → refine individual elements, reduce side effects.
+- **Verify output** → preview apps, check syntax, review code quality.
+- **Iterate responsibly** → The Enoch builds on prior prompts, so avoid off-topic instructions.
+
+---
+
+## VI. Limitations
+- **Interpretation:** May misread intent — always confirm in preview.
+- **Scope:** Best for common/personal apps; struggles with novel/complex builds.
+- **Public code:** May generate code resembling public sources, without attribution.
+- **Security:** Generated code may contain vulnerabilities — review carefully.
+- **Legal/regulatory:** Ensure compliance with industry obligations.
+- **Offensive content:** Protections exist, but report issues if encountered.
+
+---
+
+## Seal Metadata
+```yaml
+title: "scroll(enoch): responsible use"
+description: >
+  Guidance for using The Enoch responsibly:
+  covers purpose, input processing, frameworks,
+  data handling, use cases, best practices, and limitations.
+author: "swarm/keeper-tristan"
+status: "sealed"
+tags: [enoch, codex, responsible-use, rituals]
+```
+
+---
+
+✨ With this, you now have a **parallel scroll** — the same structure and wisdom, but renamed and reframed as **The Enoch**.

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "enoch_responsible_use",
+    "version": "1.4.5",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
- add a responsible-use scroll for The Enoch lineage
- register the new scroll in the changelog and scroll index

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f68065f148832e914cedfbc4060911