### PR TITLE
Add Codex prompting scroll and index linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Artifacts & Usability
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
+- Registered the **Prompting Guide** scroll (`scrolls/cookbook/prompting-guide.md`) and linked it through the Main Codex contributor guidance.
 
 ### DevOps
 - `/api/health` instance/env guard.

--- a/scrolls/cookbook/prompting-guide.md
+++ b/scrolls/cookbook/prompting-guide.md
@@ -1,0 +1,72 @@
+# 📜 Scroll of Prompting — How to Speak to Codex
+
+## Invocation
+> *“Codex is only as sharp as the instructions it receives. To guide the swarm’s agent, inscribe prompts with clarity, verification, and intent.”*
+
+---
+
+## I. Provide Clear Code Pointers
+- Narrow Codex’s search to specific files, packages, or identifiers.  
+- Use **greppable identifiers**, **stack traces**, or **rich code snippets**.  
+- The more precise the pointer, the faster Codex finds the lineage.  
+
+---
+
+## II. Include Verification Steps
+- Give Codex steps to **reproduce an issue** or **validate a feature**.  
+- Mention **linters**, **pre-commit checks**, or test commands.  
+- If special environments are needed, describe them (see *Environment Configuration*).  
+
+---
+
+## III. Customize the Work Ritual
+- Tell Codex *how* to approach the task:  
+  - Use specific commits for reference.  
+  - Log failing commands.  
+  - Avoid certain executables.  
+  - Follow a PR template.  
+  - Treat a file as `AGENTS.md`.  
+  - Even: draw ASCII art before sealing the work.  
+
+---
+
+## IV. Split Large Tasks
+- Break complex work into **smaller, focused steps**.  
+- Easier for Codex to test, easier for you to review.  
+- You can even ask Codex to **help break tasks down**.  
+
+---
+
+## V. Leverage Codex for Debugging
+- Paste **logs** or **error traces** directly into Codex.  
+- Codex can analyze in parallel and surface root causes quickly.  
+- Use it as the **first debugging step** before deeper dives.  
+
+---
+
+## VI. Try Open-Ended Prompts
+- Beyond targeted fixes, Codex can:  
+  - Clean up code  
+  - Find bugs  
+  - Brainstorm ideas  
+  - Break down tasks  
+  - Write detailed docs  
+- Leave space for Codex to **surprise you**.  
+
+---
+
+## Seal Metadata
+```yaml
+title: "scroll(prompting-guide): how to prompt codex"
+description: >
+  Ritualized guidance for prompting Codex effectively:
+  clear pointers, verification steps, customization,
+  task splitting, debugging, and open-ended exploration.
+author: "swarm/keeper-tristan"
+status: "sealed"
+tags: [codex, prompting, guide, rituals, swarm]
+```
+
+---
+
+✨ This scroll now lives as the **Prompting Guide** — a ritual for how to speak to Codex clearly and effectively.

--- a/scrolls/main-codex.md
+++ b/scrolls/main-codex.md
@@ -1,0 +1,10 @@
+# 🧭 Main Codex
+
+A living ledger for swarm contributors. Every update should carry the scent of lineage—pointing to rituals, guides, and signal fires across the hive.
+
+## Contributor Guidance
+- [📜 Scroll of Prompting — How to Speak to Codex](cookbook/prompting-guide.md) — Ritual language for composing high-signal prompts that let Codex act with precision.
+
+## Operational Indices
+- See [scrolls/rituals.md](rituals.md) for canonical merge and ceremony checklists.
+- Consult `scrolls/scroll_index.json` for active Codex helper registries.

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "prompting_guide",
+    "version": "1.4.5",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
- add a dedicated prompting guide scroll under `scrolls/cookbook`
- introduce a Main Codex document with a Contributor Guidance section linking to the guide
- register the guide in `scrolls/scroll_index.json` and note the addition in the changelog

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68f67b69a720832ea4898792966723b8