### PR TITLE
Refine ritual proxy metadata handling and risk prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [DRAFT] v1.5.0 — “Ritual Rangers” (2025-10-26)
+
+### Deployment Rituals
+- Netlify `smoke-test` function now runs preview URL checks, logs lineage metadata to Supabase, and comments results back to the PR.
+- Added Ritual Control Panel card for on-demand smoke tests with configurable path probes.
+
+### Risk & Guidance
+- Introduced Gemini-backed `risk-score` function plus dashboard badge to visualize score, reasons, and recommendations.
+- Added `predict-todos` Netlify function to propose immediate blockers and follow-ups, wiring results into dashboard UI and PR comments.
+
+### PR Stewardship
+- Added `label-pr` function to auto-apply infra/auth/dependency labels derived from touched paths.
+- Created Supabase `ritual_mutations` table and shared logger to persist operational metadata for Codex lineage overlays.
+
 ## [DRAFT] v1.0.0 — “Sentiment Sentinel” (2025-10-15)
 
 **Scope:** end-to-end ritual flow online — ingest → mood-aware generation → artifacts → growth telemetry.

--- a/netlify/functions/_logger.ts
+++ b/netlify/functions/_logger.ts
@@ -1,0 +1,60 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+type MutationLog = {
+  actor: string;
+  ritual: string;
+  status: 'success' | 'failure' | string;
+  message: string;
+  payload?: unknown;
+  response?: unknown;
+  metadata?: Record<string, unknown> | null;
+};
+
+const TABLE = process.env.SUPABASE_MUTATIONS_TABLE ?? 'ritual_mutations';
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+let cachedClient: SupabaseClient | null = null;
+
+function ensureClient(): SupabaseClient | null {
+  if (!SUPABASE_URL || !SUPABASE_KEY) {
+    console.warn('[logMutation] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY; skipping mutation log.');
+    return null;
+  }
+  if (!cachedClient) {
+    cachedClient = createClient(SUPABASE_URL, SUPABASE_KEY, {
+      auth: { persistSession: false },
+      global: { headers: { 'X-Client-Info': 'beehive-netlify-functions' } },
+    });
+  }
+  return cachedClient;
+}
+
+function payloadSize(value: unknown): number | null {
+  try {
+    const json = JSON.stringify(value);
+    return typeof json === 'string' ? Buffer.byteLength(json, 'utf8') : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function logMutation(entry: MutationLog): Promise<void> {
+  const client = ensureClient();
+  if (!client) return;
+
+  const { actor, ritual, status, message, payload = null, response = null, metadata } = entry;
+  const enrichedMetadata = {
+    ...(metadata ?? {}),
+    payloadBytes: payloadSize(payload),
+    responseBytes: payloadSize(response),
+  };
+
+  const { error } = await client
+    .from(TABLE)
+    .insert({ actor, ritual, status, message, payload, response, metadata: enrichedMetadata });
+
+  if (error) {
+    console.error('[logMutation] Failed to record mutation:', error);
+  }
+}

--- a/netlify/functions/label-pr.ts
+++ b/netlify/functions/label-pr.ts
@@ -1,0 +1,58 @@
+import type { Handler } from '@netlify/functions';
+import { logMutation } from './_logger';
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GH_TOKEN = process.env.GITHUB_PAT;
+const GH_REPO = process.env.GITHUB_REPO;
+
+function deriveLabels(files: string[]) {
+  const labels = new Set<string>();
+  if (files.some((f) => f.match(/netlify\.toml|Dockerfile|dockerfile|\.github\/workflows/))) labels.add('infra');
+  if (files.some((f) => f.match(/package\.json|lock\.json|pnpm-lock\.yaml/))) labels.add('dependencies');
+  if (files.some((f) => f.startsWith('src/routes') || f.includes('router'))) labels.add('routing');
+  if (files.some((f) => f.match(/auth|login|session|token/))) labels.add('auth');
+  if (files.some((f) => f.startsWith('scripts/'))) labels.add('scripts');
+  return Array.from(labels);
+}
+
+export const handler: Handler = async (event) => {
+  if (!CAP) return { statusCode: 500, body: 'Capability not configured' };
+  if (!GH_TOKEN || !GH_REPO) return { statusCode: 500, body: 'GitHub credentials missing' };
+
+  const actor = event.headers['x-codex-actor'] || 'Unknown Steward';
+  if (event.headers['x-codex-capability'] !== CAP) {
+    return { statusCode: 401, body: 'Unauthorized' };
+  }
+
+  let payload: any = {};
+  try {
+    payload = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON body' };
+  }
+
+  const { pr_number, files } = payload as { pr_number?: number; files?: string[] };
+  if (!pr_number || !files || !Array.isArray(files)) {
+    return { statusCode: 400, body: 'Missing pr_number or files' };
+  }
+
+  const labels = deriveLabels(files);
+  const res = await fetch(`https://api.github.com/repos/${GH_REPO}/issues/${pr_number}/labels`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${GH_TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ labels }),
+  });
+  const ok = res.status < 300;
+
+  await logMutation({
+    actor,
+    ritual: 'label-pr',
+    status: ok ? 'success' : 'failure',
+    message: ok ? `Labels applied: ${labels.join(', ')}` : `Labeling failed (${res.status})`,
+    payload: { pr_number, files },
+    response: { labels, status: res.status },
+    metadata: { labelsCount: labels.length },
+  });
+
+  return { statusCode: res.status, body: JSON.stringify({ labels }) };
+};

--- a/netlify/functions/predict-todos.ts
+++ b/netlify/functions/predict-todos.ts
@@ -1,0 +1,123 @@
+import type { Handler } from '@netlify/functions';
+import { logMutation } from './_logger';
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+const GH_TOKEN = process.env.GITHUB_PAT;
+const GH_REPO = process.env.GITHUB_REPO;
+
+type Diff = { filename: string; additions: number; deletions: number; patch: string };
+
+type TodoPayload = {
+  immediate: string[];
+  followUps: string[];
+  notes?: string[];
+};
+
+function formatList(items: string[], emptyLabel: string) {
+  if (!items || items.length === 0) return `- ${emptyLabel}`;
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+export const handler: Handler = async (event) => {
+  if (!CAP) return { statusCode: 500, body: 'Capability not configured' };
+  if (!GEMINI_API_KEY) return { statusCode: 500, body: 'Missing GEMINI_API_KEY' };
+
+  const actor = event.headers['x-codex-actor'] || 'Unknown Steward';
+  if (event.headers['x-codex-capability'] !== CAP) {
+    return { statusCode: 401, body: 'Unauthorized' };
+  }
+
+  let payload: any = {};
+  try {
+    payload = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON body' };
+  }
+
+  const { pr_number, diffs } = payload as { pr_number?: number; diffs?: Diff[] };
+  if (!pr_number) {
+    return { statusCode: 400, body: 'Missing pr_number' };
+  }
+  if (!diffs || !Array.isArray(diffs) || diffs.length === 0) {
+    return { statusCode: 400, body: 'Missing diffs' };
+  }
+
+  const hint = diffs.map((d) => `file: ${d.filename}, +${d.additions}, -${d.deletions}`).join('\n');
+  const prompt = `Review the following patches and identify TODOs for the steward.\nRespond in JSON:\n{\n  "immediate": string[],\n  "followUps": string[],\n  "notes"?: string[]\n}\nImmediate items should unblock merge; follow-ups can be logged post-merge.\nHint summary:\n${hint}\nPatches:\n${diffs
+    .map((d) => `--- ${d.filename}\n${d.patch}`)
+    .join('\n\n')}`;
+
+  let data: any = null;
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text: prompt }]}] }),
+      },
+    );
+    data = await res.json();
+  } catch (error) {
+    console.error('[predict-todos] Gemini request failed:', error);
+    return { statusCode: 502, body: 'Gemini request failed' };
+  }
+
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}';
+  let todos: TodoPayload;
+  try {
+    const parsed = JSON.parse(text);
+    todos = {
+      immediate: Array.isArray(parsed?.immediate) ? parsed.immediate : [],
+      followUps: Array.isArray(parsed?.followUps) ? parsed.followUps : [],
+      notes: Array.isArray(parsed?.notes) ? parsed.notes : [],
+    };
+  } catch {
+    todos = { immediate: [], followUps: [], notes: ['Gemini response parse failure'] };
+  }
+
+  await logMutation({
+    actor,
+    ritual: 'predict-todos',
+    status: 'success',
+    message: `TODOs generated (${todos.immediate.length} immediate, ${todos.followUps.length} follow-ups)`,
+    payload: { pr_number, diffsCount: diffs.length },
+    response: todos,
+    metadata: {
+      immediateCount: todos.immediate.length,
+      followUpCount: todos.followUps.length,
+      notesCount: todos.notes?.length ?? 0,
+    },
+  });
+
+  if (GH_TOKEN && GH_REPO) {
+    const comment = [
+      `📝 Gemini TODOs for PR #${pr_number}`,
+      '',
+      '### Immediate',
+      formatList(todos.immediate, 'No immediate blockers detected'),
+      '',
+      '### Follow-up',
+      formatList(todos.followUps, 'No follow-up items recorded'),
+    ];
+    if (todos.notes && todos.notes.length > 0) {
+      comment.push('', '### Notes', formatList(todos.notes, '—'));
+    }
+
+    try {
+      await fetch(`https://api.github.com/repos/${GH_REPO}/issues/${pr_number}/comments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${GH_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ body: comment.join('\n') }),
+      });
+    } catch (error) {
+      console.error('[predict-todos] Failed to post GitHub comment:', error);
+    }
+  }
+
+  return { statusCode: 200, body: JSON.stringify(todos) };
+};

--- a/netlify/functions/risk-score.ts
+++ b/netlify/functions/risk-score.ts
@@ -1,0 +1,97 @@
+import type { Handler } from '@netlify/functions';
+import { logMutation } from './_logger';
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+const critical = [
+  'netlify.toml',
+  'package.json',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'dockerfile',
+  'Dockerfile',
+  'scripts/',
+  '/.github/workflows/',
+  'src/worker.js',
+];
+
+export const handler: Handler = async (event) => {
+  if (!CAP) return { statusCode: 500, body: 'Capability not configured' };
+  if (!GEMINI_API_KEY) return { statusCode: 500, body: 'Missing GEMINI_API_KEY' };
+
+  const actor = event.headers['x-codex-actor'] || 'Unknown Steward';
+  if (event.headers['x-codex-capability'] !== CAP) {
+    return { statusCode: 401, body: 'Unauthorized' };
+  }
+
+  let payload: any = {};
+  try {
+    payload = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON body' };
+  }
+
+  const { diffs } = payload as {
+    diffs?: { filename: string; additions: number; deletions: number; patch: string }[];
+  };
+  if (!diffs || !Array.isArray(diffs) || diffs.length === 0) {
+    return { statusCode: 400, body: 'Missing diffs' };
+  }
+
+  const hint = diffs.map((d) => `file: ${d.filename}, +${d.additions}, -${d.deletions}`).join('\n');
+  const promptSections = [
+    `Assess risk (0-100) for this change set. Consider critical files (${critical.join(', ')})`,
+    'Config changes, dependency bumps, large deletions, and build/runtime hooks should influence the score.',
+    'Return JSON with:',
+    '{ "score": number, "level": "low|medium|high", "reasons": string[], "recommendations": string[] }',
+    'Hints:',
+    hint,
+    'Patches:',
+    diffs.map((d) => `--- ${d.filename}\n${d.patch}`).join('\n\n'),
+  ];
+  const prompt = promptSections.join('\n');
+
+  let data: any = null;
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }]}],
+        }),
+      },
+    );
+    data = await res.json();
+  } catch (error) {
+    console.error('[risk-score] Gemini request failed:', error);
+    return { statusCode: 502, body: 'Gemini request failed' };
+  }
+
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '{}';
+  let result: any;
+  try {
+    result = JSON.parse(text);
+  } catch {
+    result = {
+      score: 50,
+      level: 'medium',
+      reasons: ['Parse fallback'],
+      recommendations: ['Return structured JSON'],
+    };
+  }
+
+  await logMutation({
+    actor,
+    ritual: 'risk-score',
+    status: 'success',
+    message: `Risk ${result.level} (${result.score})`,
+    payload: { count: diffs.length },
+    response: result,
+    metadata: { filesCount: diffs.length, level: result.level, score: result.score },
+  });
+
+  return { statusCode: 200, body: JSON.stringify(result) };
+};

--- a/netlify/functions/smoke-test.ts
+++ b/netlify/functions/smoke-test.ts
@@ -1,0 +1,84 @@
+import type { Handler } from '@netlify/functions';
+import { logMutation } from './_logger';
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GH_TOKEN = process.env.GITHUB_PAT;
+const GH_REPO = process.env.GITHUB_REPO;
+
+async function check(url: string) {
+  try {
+    const res = await fetch(url, { redirect: 'follow' });
+    const ok = res.status >= 200 && res.status < 400;
+    return { url, status: res.status, ok };
+  } catch (error: any) {
+    return { url, status: 0, ok: false, err: String(error) };
+  }
+}
+
+export const handler: Handler = async (event) => {
+  if (!CAP) return { statusCode: 500, body: 'Capability not configured' };
+
+  const actor = event.headers['x-codex-actor'] || 'Unknown Steward';
+  if (event.headers['x-codex-capability'] !== CAP) {
+    return { statusCode: 401, body: 'Unauthorized' };
+  }
+
+  let body: any = {};
+  try {
+    body = event.body ? JSON.parse(event.body) : {};
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON body' };
+  }
+
+  const { pr_number, preview_url, tests = ['/', '/favicon.ico'] } = body as {
+    pr_number?: number;
+    preview_url?: string;
+    tests?: string[];
+  };
+
+  if (!preview_url) {
+    return { statusCode: 400, body: 'Missing preview_url' };
+  }
+
+  const list = Array.isArray(tests) && tests.length > 0 ? tests : ['/'];
+  const targetResults = await Promise.all(
+    list.map((test) => check(new URL(test, preview_url).toString())),
+  );
+  const pass = targetResults.every((result) => result.ok);
+  const summary = targetResults
+    .map((result) => `- ${result.url} → ${result.ok ? '✅' : '❌'} (status ${result.status})`)
+    .join('\n');
+
+  await logMutation({
+    actor,
+    ritual: 'smoke-test',
+    status: pass ? 'success' : 'failure',
+    message: pass ? 'Smoke tests passed' : 'Smoke tests failed',
+    payload: { pr_number, preview_url, tests: list },
+    response: { results: targetResults },
+    metadata: { previewUrl: preview_url, testsCount: list.length, pass },
+  });
+
+  if (pr_number && GH_TOKEN && GH_REPO) {
+    try {
+      const bodyText = `🧪 Smoke tests on ${preview_url}\n\n${summary}\n\nResult: ${
+        pass ? '✅ Pass' : '❌ Fail'
+      }`;
+      await fetch(`https://api.github.com/repos/${GH_REPO}/issues/${pr_number}/comments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${GH_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ body: bodyText }),
+      });
+    } catch (error) {
+      console.error('[smoke-test] Failed to post GitHub comment:', error);
+    }
+  }
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({ pass, results: targetResults }),
+  };
+};

--- a/scrolls/rituals.md
+++ b/scrolls/rituals.md
@@ -18,9 +18,28 @@ A centralized registry for operational rituals in the Beehive repository. Every 
 
 ---
 
-**How to use:**  
-- Review this index before every PR or milestone.  
-- Follow the linked rituals for consistent, audit-ready operations.  
+## 🟢 Netlify Ritual Automations (v1.5.0)
+- **Function:** `/.netlify/functions/smoke-test`
+- **Purpose:** Runs post-deploy smoke tests against preview URLs, logs to Supabase, and comments back on the PR.
+- **UI Trigger:** Dashboard → Ritual Control Panel → “Run smoke tests”.
+
+- **Function:** `/.netlify/functions/risk-score`
+- **Purpose:** Scores the current patch via Gemini, highlighting risky files, heavy churn, and config changes.
+- **UI Trigger:** Dashboard → Ritual Control Panel → “Score patch risk”.
+
+- **Function:** `/.netlify/functions/label-pr`
+- **Purpose:** Applies GitHub labels inferred from touched paths (infra, auth, routing, dependencies, scripts).
+- **UI Trigger:** Dashboard → Ritual Control Panel → “Label PR”.
+
+- **Function:** `/.netlify/functions/predict-todos`
+- **Purpose:** Synthesizes immediate TODOs and follow-up work from the diff and posts them to the PR conversation.
+- **UI Trigger:** Dashboard → Ritual Control Panel → “Predict TODOs”.
+
+---
+
+**How to use:**
+- Review this index before every PR or milestone.
+- Follow the linked rituals for consistent, audit-ready operations.
 - Update this index when new ritual scrolls are added.
 
 ---

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,25 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "smoke_test_ritual",
+    "version": "1.5.0",
+    "enabled": true
+  },
+  {
+    "name": "risk_score_ritual",
+    "version": "1.5.0",
+    "enabled": true
+  },
+  {
+    "name": "label_pr_ritual",
+    "version": "1.5.0",
+    "enabled": true
+  },
+  {
+    "name": "predict_todos_ritual",
+    "version": "1.5.0",
+    "enabled": true
   }
 ]

--- a/src/app/api/rituals/[ritual]/route.ts
+++ b/src/app/api/rituals/[ritual]/route.ts
@@ -1,0 +1,153 @@
+import { Buffer } from 'node:buffer';
+import { NextResponse, type NextRequest } from 'next/server';
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+
+function resolveBaseUrl(): string {
+  const candidates = [
+    process.env.RITUAL_FUNCTION_BASE,
+    process.env.NETLIFY_SITE_URL,
+    process.env.URL,
+    process.env.DEPLOY_URL,
+    process.env.SITE_URL,
+    process.env.NEXT_PUBLIC_SITE_URL,
+  ];
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.replace(/\/$/, '');
+    }
+  }
+  return 'http://localhost:8888';
+}
+
+async function forwardRitual(
+  ritual: string,
+  payload: Record<string, unknown>,
+  actor: string,
+): Promise<{ ok: boolean; status: number; data?: unknown; error?: string; metadata?: Record<string, unknown> }> {
+  if (!CAP) {
+    return { ok: false, status: 500, error: 'Capability not configured' };
+  }
+
+  const base = resolveBaseUrl();
+  const target = `${base}/.netlify/functions/${ritual}`;
+
+  let requestBody = '{}';
+  try {
+    requestBody = JSON.stringify(payload ?? {});
+  } catch (error: any) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Ritual payload serialization failed: ${String(error)}`,
+    };
+  }
+  const requestBytes = Buffer.byteLength(requestBody, 'utf8');
+
+  let response: Response;
+  try {
+    response = await fetch(target, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-codex-capability': CAP,
+        'x-codex-actor': actor,
+      },
+      body: requestBody,
+    });
+  } catch (error: any) {
+    return {
+      ok: false,
+      status: 502,
+      error: `Ritual forward failed: ${String(error)}`,
+    };
+  }
+
+  const text = await response.text();
+  const responseBytes = Buffer.byteLength(text, 'utf8');
+  const contentLengthHeader = response.headers.get('content-length');
+  const parsedContentLength = contentLengthHeader ? Number(contentLengthHeader) : undefined;
+  const contentLength =
+    typeof parsedContentLength === 'number' && Number.isFinite(parsedContentLength)
+      ? parsedContentLength
+      : undefined;
+  const requestId = response.headers.get('x-nf-request-id') ?? undefined;
+
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok) {
+    const message = typeof json?.error === 'string' ? json.error : text || 'Ritual invocation failed';
+    return {
+      ok: false,
+      status: response.status,
+      error: message,
+      metadata: {
+        requestId,
+        functionUrl: target,
+        statusCode: response.status,
+        requestBytes,
+        responseBytes,
+        contentLength,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    status: response.status,
+    data: json ?? text ?? null,
+    metadata: {
+      requestId,
+      functionUrl: target,
+      statusCode: response.status,
+      requestBytes,
+      responseBytes,
+      contentLength,
+    },
+  };
+}
+
+export async function POST(request: NextRequest, { params }: { params: { ritual: string } }) {
+  const ritual = params.ritual;
+  if (!ritual) {
+    return NextResponse.json({ ok: false, error: 'Missing ritual name', status: 400 }, { status: 400 });
+  }
+
+  let incoming: any = {};
+  try {
+    incoming = await request.json();
+  } catch {
+    incoming = {};
+  }
+
+  const actor =
+    (typeof incoming.actor === 'string' && incoming.actor.trim()) ||
+    request.headers.get('x-codex-actor') ||
+    'Dashboard Steward';
+
+  const { actor: _omit, ...payload } =
+    incoming && typeof incoming === 'object' ? (incoming as Record<string, unknown>) : {};
+
+  const result = await forwardRitual(ritual, payload, actor);
+  if (!result.ok) {
+    return NextResponse.json(
+      { ok: false, status: result.status, error: result.error, metadata: result.metadata },
+      { status: result.status },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      status: result.status,
+      data: result.data,
+      metadata: result.metadata,
+    },
+    { status: 200 },
+  );
+}

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,6 +1,7 @@
 import SentimentCard from '@/components/SentimentCard';
 import LineageCard from '@/components/LineageCard';
 import SentimentHistogram from '@/components/SentimentHistogram';
+import RitualControlPanel from '@/components/RitualControlPanel';
 
 export default function AnalyticsPage() {
   return (
@@ -11,6 +12,7 @@ export default function AnalyticsPage() {
         <LineageCard />
       </div>
       <SentimentHistogram hours={24} />
+      <RitualControlPanel />
     </main>
   );
 }

--- a/src/components/RiskBadge.tsx
+++ b/src/components/RiskBadge.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+type Level = 'low' | 'medium' | 'high';
+
+const map: Record<Level, string> = {
+  low: 'bg-emerald-600',
+  medium: 'bg-amber-500',
+  high: 'bg-rose-600',
+};
+
+export default function RiskBadge({ level, score }: { level: Level; score: number }) {
+  return (
+    <span className={`px-2 py-1 rounded text-white text-xs font-semibold ${map[level]}`}>
+      Risk: {level} ({score})
+    </span>
+  );
+}

--- a/src/components/RitualControlPanel.tsx
+++ b/src/components/RitualControlPanel.tsx
@@ -1,0 +1,458 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import RiskBadge from './RiskBadge';
+import { call } from '@/lib/rituals';
+
+type SmokeResult = {
+  pass: boolean;
+  results: { url: string; status: number; ok: boolean; err?: string }[];
+};
+
+type RiskResult = {
+  score: number;
+  level: 'low' | 'medium' | 'high';
+  reasons?: string[];
+  recommendations?: string[];
+};
+
+type TodoResult = {
+  immediate: string[];
+  followUps: string[];
+  notes?: string[];
+};
+
+type Metadata = Record<string, unknown> | null;
+
+type DiffInput = { filename: string; additions: number; deletions: number; patch: string };
+
+function renderMetadata(metadata: Metadata) {
+  if (!metadata) return null;
+  const entries = Object.entries(metadata).filter(([, value]) => value !== undefined && value !== null);
+  if (entries.length === 0) return null;
+  return (
+    <div className="mt-2 text-[11px] text-gray-400">
+      {entries.map(([key, value]) => `${key}: ${String(value)}`).join(' • ')}
+    </div>
+  );
+}
+
+function parseFiles(text: string): string[] {
+  return text
+    .split(/[\n,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function parseNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function useDiffMemo(diffText: string): { raw: string; parsed: DiffInput[] | null; error: string | null } {
+  return useMemo(() => {
+    if (!diffText.trim()) {
+      return { raw: diffText, parsed: [], error: null };
+    }
+    try {
+      const candidate = JSON.parse(diffText);
+      if (!Array.isArray(candidate)) {
+        return { raw: diffText, parsed: null, error: 'Diff JSON must be an array' };
+      }
+      return { raw: diffText, parsed: candidate as DiffInput[], error: null };
+    } catch (error: any) {
+      return { raw: diffText, parsed: null, error: error?.message ?? 'Invalid JSON' };
+    }
+  }, [diffText]);
+}
+
+export default function RitualControlPanel() {
+  const [prNumber, setPrNumber] = useState('');
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [tests, setTests] = useState('/,/favicon.ico');
+  const [diffText, setDiffText] = useState(
+    '[\n  {\n    "filename": "src/example.ts",\n    "additions": 5,\n    "deletions": 1,\n    "patch": "+const demo = true;\\n"\n  }\n]'
+  );
+  const diffMemo = useDiffMemo(diffText);
+  const [filesText, setFilesText] = useState('src/example.ts\nnetlify.toml');
+
+  const [smokeResult, setSmokeResult] = useState<SmokeResult | null>(null);
+  const [smokeMeta, setSmokeMeta] = useState<Metadata>(null);
+  const [smokeError, setSmokeError] = useState<string | null>(null);
+  const [smokeBusy, setSmokeBusy] = useState(false);
+
+  const [riskResult, setRiskResult] = useState<RiskResult | null>(null);
+  const [riskMeta, setRiskMeta] = useState<Metadata>(null);
+  const [riskError, setRiskError] = useState<string | null>(null);
+  const [riskBusy, setRiskBusy] = useState(false);
+
+  const [labelResult, setLabelResult] = useState<string[] | null>(null);
+  const [labelMeta, setLabelMeta] = useState<Metadata>(null);
+  const [labelError, setLabelError] = useState<string | null>(null);
+  const [labelBusy, setLabelBusy] = useState(false);
+
+  const [todoResult, setTodoResult] = useState<TodoResult | null>(null);
+  const [todoMeta, setTodoMeta] = useState<Metadata>(null);
+  const [todoError, setTodoError] = useState<string | null>(null);
+  const [todoBusy, setTodoBusy] = useState(false);
+
+  async function runSmoke() {
+    const target = previewUrl.trim();
+    if (!target) {
+      setSmokeError('Preview URL is required');
+      return;
+    }
+    const pr = parseNumber(prNumber);
+    if (prNumber.trim() && pr === undefined) {
+      setSmokeError('PR number must be numeric');
+      return;
+    }
+    const list = parseFiles(tests);
+
+    setSmokeBusy(true);
+    setSmokeError(null);
+    try {
+      const response = await call<SmokeResult>('smoke-test', {
+        actor: 'Dashboard Control Panel',
+        pr_number: pr,
+        preview_url: target,
+        tests: list.length > 0 ? list : undefined,
+      });
+      setSmokeResult(response.data);
+      setSmokeMeta(response.metadata ?? null);
+    } catch (error: any) {
+      setSmokeError(error?.message ?? 'Smoke test ritual failed');
+      setSmokeResult(null);
+      setSmokeMeta(error?.metadata ?? null);
+    } finally {
+      setSmokeBusy(false);
+    }
+  }
+
+  async function runRisk() {
+    if (diffMemo.error) {
+      setRiskError(diffMemo.error);
+      return;
+    }
+    const diffs = diffMemo.parsed ?? [];
+    if (diffs.length === 0) {
+      setRiskError('Provide at least one diff for scoring');
+      return;
+    }
+
+    setRiskBusy(true);
+    setRiskError(null);
+    try {
+      const response = await call<RiskResult>('risk-score', {
+        actor: 'Dashboard Control Panel',
+        diffs,
+      });
+      setRiskResult(response.data);
+      setRiskMeta(response.metadata ?? null);
+    } catch (error: any) {
+      setRiskError(error?.message ?? 'Risk score ritual failed');
+      setRiskResult(null);
+      setRiskMeta(error?.metadata ?? null);
+    } finally {
+      setRiskBusy(false);
+    }
+  }
+
+  async function runLabel() {
+    const pr = parseNumber(prNumber);
+    if (!pr) {
+      setLabelError('PR number required');
+      return;
+    }
+    const files = parseFiles(filesText);
+    if (files.length === 0) {
+      setLabelError('List at least one touched file');
+      return;
+    }
+
+    setLabelBusy(true);
+    setLabelError(null);
+    try {
+      const response = await call<{ labels: string[] }>('label-pr', {
+        actor: 'Dashboard Control Panel',
+        pr_number: pr,
+        files,
+      });
+      setLabelResult(response.data.labels);
+      setLabelMeta(response.metadata ?? null);
+    } catch (error: any) {
+      setLabelError(error?.message ?? 'Label ritual failed');
+      setLabelResult(null);
+      setLabelMeta(error?.metadata ?? null);
+    } finally {
+      setLabelBusy(false);
+    }
+  }
+
+  async function runTodos() {
+    const pr = parseNumber(prNumber);
+    if (!pr) {
+      setTodoError('PR number required');
+      return;
+    }
+    if (diffMemo.error) {
+      setTodoError(diffMemo.error);
+      return;
+    }
+    const diffs = diffMemo.parsed ?? [];
+    if (diffs.length === 0) {
+      setTodoError('Provide at least one diff for TODO synthesis');
+      return;
+    }
+
+    setTodoBusy(true);
+    setTodoError(null);
+    try {
+      const response = await call<TodoResult>('predict-todos', {
+        actor: 'Dashboard Control Panel',
+        pr_number: pr,
+        diffs,
+      });
+      setTodoResult(response.data);
+      setTodoMeta(response.metadata ?? null);
+    } catch (error: any) {
+      setTodoError(error?.message ?? 'TODO ritual failed');
+      setTodoResult(null);
+      setTodoMeta(error?.metadata ?? null);
+    } finally {
+      setTodoBusy(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border bg-white p-6 shadow-sm space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Ritual Control Panel</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Trigger Netlify rituals after deploys and capture Codex lineage metadata without leaving the dashboard.
+        </p>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-xl border p-4">
+          <h3 className="text-sm font-semibold">Post-deploy smoke tests</h3>
+          <p className="mt-1 text-xs text-gray-500">Runs HTTP checks against the Netlify preview and records the outcome.</p>
+          <div className="mt-3 space-y-3 text-xs">
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">PR number (optional for smoke)</span>
+              <input
+                value={prNumber}
+                onChange={(event) => setPrNumber(event.target.value)}
+                className="w-full rounded-lg border px-3 py-2"
+                placeholder="123"
+                inputMode="numeric"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">Preview URL</span>
+              <input
+                value={previewUrl}
+                onChange={(event) => setPreviewUrl(event.target.value)}
+                className="w-full rounded-lg border px-3 py-2"
+                placeholder="https://deploy-preview--site.netlify.app"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">Paths to probe (comma or newline)</span>
+              <textarea
+                value={tests}
+                onChange={(event) => setTests(event.target.value)}
+                rows={2}
+                className="w-full rounded-lg border px-3 py-2"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={runSmoke}
+              disabled={smokeBusy}
+              className="rounded bg-teal-600 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {smokeBusy ? 'Running…' : 'Run smoke tests'}
+            </button>
+            {smokeError && <div className="text-xs text-rose-600">{smokeError}</div>}
+            {smokeResult && (
+              <div className="space-y-2">
+                <div className="text-xs font-semibold text-gray-700">
+                  Result: {smokeResult.pass ? '✅ Pass' : '❌ Fail'}
+                </div>
+                <ul className="space-y-1 text-[11px] text-gray-600">
+                  {smokeResult.results.map((item) => (
+                    <li key={item.url}>
+                      {item.ok ? '✅' : '❌'} {item.url} <span className="text-gray-400">(status {item.status})</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {renderMetadata(smokeMeta)}
+          </div>
+        </div>
+
+        <div className="rounded-xl border p-4">
+          <h3 className="text-sm font-semibold">Patch risk scoring</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Sends diffs to Gemini for a risk estimate, flagging infra/config hotspots and heavy churn.
+          </p>
+          <div className="mt-3 space-y-3 text-xs">
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">Diff JSON</span>
+              <textarea
+                value={diffText}
+                onChange={(event) => setDiffText(event.target.value)}
+                rows={8}
+                className="w-full rounded-lg border px-3 py-2 font-mono text-[11px]"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={runRisk}
+              disabled={riskBusy}
+              className="rounded bg-slate-900 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {riskBusy ? 'Scoring…' : 'Score patch risk'}
+            </button>
+            {riskError && <div className="text-xs text-rose-600">{riskError}</div>}
+            {riskResult && (
+              <div className="space-y-2">
+                <RiskBadge level={riskResult.level} score={riskResult.score} />
+                {riskResult.reasons && riskResult.reasons.length > 0 && (
+                  <div>
+                    <div className="text-[11px] font-semibold text-gray-700">Reasons</div>
+                    <ul className="mt-1 space-y-1 text-[11px] text-gray-600">
+                      {riskResult.reasons.map((reason, index) => (
+                        <li key={index}>• {reason}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {riskResult.recommendations && riskResult.recommendations.length > 0 && (
+                  <div>
+                    <div className="text-[11px] font-semibold text-gray-700">Recommendations</div>
+                    <ul className="mt-1 space-y-1 text-[11px] text-gray-600">
+                      {riskResult.recommendations.map((item, index) => (
+                        <li key={index}>• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+            {renderMetadata(riskMeta)}
+          </div>
+        </div>
+
+        <div className="rounded-xl border p-4">
+          <h3 className="text-sm font-semibold">Mutation labeling</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Applies GitHub labels by scanning touched paths for infra, auth, routing, or dependency signals.
+          </p>
+          <div className="mt-3 space-y-3 text-xs">
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">PR number</span>
+              <input
+                value={prNumber}
+                onChange={(event) => setPrNumber(event.target.value)}
+                className="w-full rounded-lg border px-3 py-2"
+                placeholder="123"
+                inputMode="numeric"
+              />
+            </label>
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">Touched files</span>
+              <textarea
+                value={filesText}
+                onChange={(event) => setFilesText(event.target.value)}
+                rows={5}
+                className="w-full rounded-lg border px-3 py-2 font-mono text-[11px]"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={runLabel}
+              disabled={labelBusy}
+              className="rounded bg-indigo-600 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {labelBusy ? 'Labeling…' : 'Label PR'}
+            </button>
+            {labelError && <div className="text-xs text-rose-600">{labelError}</div>}
+            {labelResult && (
+              <div className="space-y-1 text-[11px] text-gray-600">
+                <div className="font-semibold text-gray-700">Applied labels</div>
+                <div>{labelResult.length > 0 ? labelResult.join(', ') : '—'}</div>
+              </div>
+            )}
+            {renderMetadata(labelMeta)}
+          </div>
+        </div>
+
+        <div className="rounded-xl border p-4">
+          <h3 className="text-sm font-semibold">Gemini TODO synthesis</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Generates immediate blockers and follow-up ideas directly from the diff context.
+          </p>
+          <div className="mt-3 space-y-3 text-xs">
+            <label className="block space-y-1">
+              <span className="font-medium text-gray-700">PR number</span>
+              <input
+                value={prNumber}
+                onChange={(event) => setPrNumber(event.target.value)}
+                className="w-full rounded-lg border px-3 py-2"
+                placeholder="123"
+                inputMode="numeric"
+              />
+            </label>
+            <p className="text-[11px] text-gray-500">
+              Uses the same diff JSON as the risk scorer above.
+            </p>
+            <button
+              type="button"
+              onClick={runTodos}
+              disabled={todoBusy}
+              className="rounded bg-amber-500 px-4 py-2 text-white disabled:opacity-50"
+            >
+              {todoBusy ? 'Predicting…' : 'Predict TODOs'}
+            </button>
+            {todoError && <div className="text-xs text-rose-600">{todoError}</div>}
+            {todoResult && (
+              <div className="space-y-2 text-[11px] text-gray-600">
+                <div>
+                  <div className="font-semibold text-gray-700">Immediate</div>
+                  <ul className="mt-1 space-y-1">
+                    {(todoResult.immediate.length ? todoResult.immediate : ['No immediate blockers detected']).map((item, index) => (
+                      <li key={`immediate-${index}`}>• {item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <div className="font-semibold text-gray-700">Follow-up</div>
+                  <ul className="mt-1 space-y-1">
+                    {(todoResult.followUps.length ? todoResult.followUps : ['No follow-up items recorded']).map((item, index) => (
+                      <li key={`follow-${index}`}>• {item}</li>
+                    ))}
+                  </ul>
+                </div>
+                {todoResult.notes && todoResult.notes.length > 0 && (
+                  <div>
+                    <div className="font-semibold text-gray-700">Notes</div>
+                    <ul className="mt-1 space-y-1">
+                      {todoResult.notes.map((item, index) => (
+                        <li key={`note-${index}`}>• {item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            )}
+            {renderMetadata(todoMeta)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/rituals.ts
+++ b/src/lib/rituals.ts
@@ -1,0 +1,37 @@
+'use client';
+
+type RitualPayload = Record<string, unknown> & { actor?: string };
+
+type RitualResponse<T> = {
+  ok: true;
+  status: number;
+  data: T;
+  metadata?: Record<string, unknown>;
+};
+
+export async function call<T = unknown>(ritual: string, payload: RitualPayload = {}): Promise<RitualResponse<T>> {
+  const { actor, ...rest } = payload;
+  const response = await fetch(`/api/rituals/${ritual}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ ...rest, actor }),
+  });
+
+  let json: any = null;
+  try {
+    json = await response.json();
+  } catch {
+    json = null;
+  }
+
+  if (!response.ok || !json?.ok) {
+    const message = json?.error || `Ritual ${ritual} failed (${response.status})`;
+    const error = new Error(message) as Error & { metadata?: Record<string, unknown> };
+    if (json?.metadata && typeof json.metadata === 'object') {
+      error.metadata = json.metadata as Record<string, unknown>;
+    }
+    throw error;
+  }
+
+  return json as RitualResponse<T>;
+}

--- a/supabase/sql/2025-10-26_ritual_mutations.sql
+++ b/supabase/sql/2025-10-26_ritual_mutations.sql
@@ -1,0 +1,16 @@
+create table if not exists public.ritual_mutations (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  actor text not null,
+  ritual text not null,
+  status text not null,
+  message text not null,
+  payload jsonb,
+  response jsonb,
+  metadata jsonb
+);
+
+alter table public.ritual_mutations enable row level security;
+
+create index if not exists ritual_mutations_created_idx on public.ritual_mutations (created_at desc);
+create index if not exists ritual_mutations_ritual_idx on public.ritual_mutations (ritual);


### PR DESCRIPTION
## Summary
- fix the risk-score prompt assembly so the Gemini request is well-formed
- capture request/response sizing and request IDs in the ritual proxy, exposing metadata on success and failure
- surface ritual metadata in the dashboard control panel, even when calls error, by plumbing the data through the client helper

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68f7cc661064832eb23dd83ed16ef849