### PR TITLE
Codex: Chronicle mutation lineage across the hive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+- Codex mutation lineage: Supabase `codex_mutations` log + broadcast rituals stream into dashboard feed.
 ## v1.4.5 — Remix Scheduler (2025-10-19)
 
 ### Codex Helpers

--- a/netlify/functions/_logger.ts
+++ b/netlify/functions/_logger.ts
@@ -1,0 +1,38 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error("Missing Supabase credentials for mutation logger");
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+type MutationStatus = "success" | "failure";
+
+type MutationLogEntry = {
+  actor: string;
+  ritual: string;
+  target?: string;
+  status: MutationStatus;
+  message: string;
+  payload?: unknown;
+  response?: unknown;
+};
+
+export async function logMutation(entry: MutationLogEntry) {
+  const { error } = await supabase.from("codex_mutations").insert({
+    actor: entry.actor,
+    ritual: entry.ritual,
+    target: entry.target ?? null,
+    status: entry.status,
+    message: entry.message,
+    payload: entry.payload ?? null,
+    response: entry.response ?? null,
+  });
+
+  if (error) {
+    console.error("Failed to log mutation", error);
+  }
+}

--- a/netlify/functions/broadcast-discord.ts
+++ b/netlify/functions/broadcast-discord.ts
@@ -1,0 +1,69 @@
+import type { Handler } from "@netlify/functions";
+import { Buffer } from "node:buffer";
+import { logMutation } from "./_logger";
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const WEBHOOK = process.env.DISCORD_WEBHOOK_URL;
+
+function decodeBody(body: string | null, isBase64: boolean | undefined) {
+  if (!body) return "{}";
+  return isBase64 ? Buffer.from(body, "base64").toString("utf8") : body;
+}
+
+export const handler: Handler = async (event) => {
+  const actor = event.headers?.["x-codex-actor"] ?? event.headers?.["X-Codex-Actor"] ?? "Unknown Steward";
+
+  if (!CAP || !WEBHOOK) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-discord",
+      status: "failure",
+      message: "Missing Discord webhook env",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 500, body: "Server misconfigured" };
+  }
+
+  if ((event.headers?.["x-codex-capability"] ?? event.headers?.["X-Codex-Capability"]) !== CAP) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-discord",
+      status: "failure",
+      message: "Unauthorized capability",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 401, body: "Unauthorized" };
+  }
+
+  const rawBody = decodeBody(event.body ?? null, event.isBase64Encoded);
+  let payload: { message?: string };
+  try {
+    payload = JSON.parse(rawBody || "{}");
+  } catch {
+    return { statusCode: 400, body: "Invalid JSON" };
+  }
+
+  const message = payload.message ?? "Codex broadcast";
+
+  const response = await fetch(WEBHOOK, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ content: message }),
+  });
+
+  const text = await response.text();
+  const ok = response.status >= 200 && response.status < 300;
+
+  await logMutation({
+    actor,
+    ritual: "broadcast-discord",
+    status: ok ? "success" : "failure",
+    message: ok ? "Discord broadcast sent" : `Discord failed (${response.status})`,
+    payload: { message },
+    response: { raw: text },
+  });
+
+  return { statusCode: response.status, body: text };
+};

--- a/netlify/functions/broadcast-gist.ts
+++ b/netlify/functions/broadcast-gist.ts
@@ -1,0 +1,99 @@
+import type { Handler } from "@netlify/functions";
+import { Buffer } from "node:buffer";
+import { logMutation } from "./_logger";
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GH_TOKEN = process.env.GITHUB_PAT;
+
+function decodeBody(body: string | null, isBase64: boolean | undefined) {
+  if (!body) return "{}";
+  return isBase64 ? Buffer.from(body, "base64").toString("utf8") : body;
+}
+
+function safeJson(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+export const handler: Handler = async (event) => {
+  const actor = event.headers?.["x-codex-actor"] ?? event.headers?.["X-Codex-Actor"] ?? "Unknown Steward";
+
+  if (!CAP || !GH_TOKEN) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-gist",
+      status: "failure",
+      message: "Missing GitHub capability env",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 500, body: "Server misconfigured" };
+  }
+
+  if ((event.headers?.["x-codex-capability"] ?? event.headers?.["X-Codex-Capability"]) !== CAP) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-gist",
+      status: "failure",
+      message: "Unauthorized capability",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 401, body: "Unauthorized" };
+  }
+
+  const rawBody = decodeBody(event.body ?? null, event.isBase64Encoded);
+  let payload: { filename?: string; content?: string; description?: string; public?: boolean };
+  try {
+    payload = JSON.parse(rawBody || "{}");
+  } catch {
+    return { statusCode: 400, body: "Invalid JSON" };
+  }
+
+  const { filename, content, description = "Codex scroll", public: isPublic = false } = payload;
+
+  if (!filename || !content) {
+    return { statusCode: 400, body: "Missing filename or content" };
+  }
+
+  const response = await fetch("https://api.github.com/gists", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${GH_TOKEN}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({
+      description,
+      public: isPublic,
+      files: { [filename]: { content } },
+    }),
+  });
+
+  const text = await response.text();
+  const ok = response.status >= 200 && response.status < 300;
+  let target = "";
+  try {
+    const json = JSON.parse(text);
+    if (json && typeof json === "object") {
+      target = json.html_url ?? "";
+    }
+  } catch {
+    target = "";
+  }
+
+  await logMutation({
+    actor,
+    ritual: "broadcast-gist",
+    target,
+    status: ok ? "success" : "failure",
+    message: ok ? "Gist published" : `Gist failed (${response.status})`,
+    payload: { filename, description, public: isPublic },
+    response: safeJson(text),
+  });
+
+  return { statusCode: response.status, body: text };
+};

--- a/netlify/functions/broadcast-netlify.ts
+++ b/netlify/functions/broadcast-netlify.ts
@@ -1,0 +1,48 @@
+import type { Handler } from "@netlify/functions";
+import { logMutation } from "./_logger";
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const BUILD_HOOK = process.env.NETLIFY_BUILD_HOOK_URL;
+
+export const handler: Handler = async (event) => {
+  const actor = event.headers?.["x-codex-actor"] ?? event.headers?.["X-Codex-Actor"] ?? "Unknown Steward";
+
+  if (!CAP || !BUILD_HOOK) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-netlify",
+      status: "failure",
+      message: "Missing Netlify hook env",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 500, body: "Server misconfigured" };
+  }
+
+  if ((event.headers?.["x-codex-capability"] ?? event.headers?.["X-Codex-Capability"]) !== CAP) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-netlify",
+      status: "failure",
+      message: "Unauthorized capability",
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 401, body: "Unauthorized" };
+  }
+
+  const response = await fetch(BUILD_HOOK, { method: "POST" });
+  const text = await response.text();
+  const ok = response.status >= 200 && response.status < 300;
+
+  await logMutation({
+    actor,
+    ritual: "broadcast-netlify",
+    status: ok ? "success" : "failure",
+    message: ok ? "Netlify build triggered" : `Netlify hook failed (${response.status})`,
+    payload: {},
+    response: { raw: text },
+  });
+
+  return { statusCode: response.status, body: text };
+};

--- a/netlify/functions/broadcast-pr.ts
+++ b/netlify/functions/broadcast-pr.ts
@@ -1,0 +1,95 @@
+import type { Handler } from "@netlify/functions";
+import { Buffer } from "node:buffer";
+import { logMutation } from "./_logger";
+
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+const GH_TOKEN = process.env.GITHUB_PAT;
+const GH_REPO = process.env.GITHUB_REPO;
+
+function decodeBody(eventBody: string | null, isBase64: boolean | undefined) {
+  if (!eventBody) return "{}";
+  return isBase64 ? Buffer.from(eventBody, "base64").toString("utf8") : eventBody;
+}
+
+function safeJson(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+export const handler: Handler = async (event) => {
+  const actor = event.headers?.["x-codex-actor"] ?? event.headers?.["X-Codex-Actor"] ?? "Unknown Steward";
+
+  if (!CAP || !GH_TOKEN || !GH_REPO) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-pr",
+      status: "failure",
+      message: "Missing GitHub or capability env", 
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 500, body: "Server misconfigured" };
+  }
+
+  if ((event.headers?.["x-codex-capability"] ?? event.headers?.["X-Codex-Capability"]) !== CAP) {
+    await logMutation({
+      actor,
+      ritual: "broadcast-pr",
+      status: "failure",
+      message: "Unauthorized capability", 
+      payload: {},
+      response: {},
+    });
+    return { statusCode: 401, body: "Unauthorized" };
+  }
+
+  const rawBody = decodeBody(event.body ?? null, event.isBase64Encoded);
+  let payload: { title?: string; body?: string; base?: string; head?: string };
+  try {
+    payload = JSON.parse(rawBody || "{}");
+  } catch {
+    return { statusCode: 400, body: "Invalid JSON" };
+  }
+
+  const { title, body, base = "main", head } = payload;
+  if (!head) {
+    return { statusCode: 400, body: "Missing 'head' branch" };
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${GH_REPO}/pulls`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${GH_TOKEN}`,
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github+json",
+    },
+    body: JSON.stringify({ title, body, base, head }),
+  });
+
+  const text = await response.text();
+  const ok = response.status >= 200 && response.status < 300;
+  let target = "";
+  try {
+    const json = JSON.parse(text);
+    if (json && typeof json === "object") {
+      target = json.html_url ?? "";
+    }
+  } catch {
+    target = "";
+  }
+
+  await logMutation({
+    actor,
+    ritual: "broadcast-pr",
+    target,
+    status: ok ? "success" : "failure",
+    message: ok ? "PR created" : `PR failed (${response.status})`,
+    payload: { title, body, base, head },
+    response: safeJson(text),
+  });
+
+  return { statusCode: response.status, body: text };
+};

--- a/netlify/functions/mutations.ts
+++ b/netlify/functions/mutations.ts
@@ -1,0 +1,39 @@
+import type { Handler } from "@netlify/functions";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const CAP = process.env.CODEX_CAPABILITY_KEY;
+
+if (!supabaseUrl || !serviceKey) {
+  throw new Error("Missing Supabase credentials for mutations function");
+}
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+export const handler: Handler = async (event) => {
+  if (!CAP) {
+    return { statusCode: 500, body: "Server misconfigured" };
+  }
+
+  const headerCap = event.headers?.["x-codex-capability"] ?? event.headers?.["X-Codex-Capability"];
+  if (headerCap !== CAP) {
+    return { statusCode: 401, body: "Unauthorized" };
+  }
+
+  const { data, error } = await supabase
+    .from("codex_mutations")
+    .select("id,created_at,actor,ritual,target,status,message")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return { statusCode: 500, body: error.message };
+  }
+
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(data ?? []),
+  };
+};

--- a/scripts/powershell/Codex.psm1
+++ b/scripts/powershell/Codex.psm1
@@ -1,0 +1,57 @@
+function Invoke-CodexBroadcast {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('pr', 'gist', 'netlify', 'discord', 'gemini')]
+        [string]$Type,
+
+        [hashtable]$Payload = @{},
+
+        [string]$BaseUrl = 'https://beehive.netlify.app/.netlify/functions',
+
+        [string]$Capability = $env:CODEX_CAPABILITY,
+
+        [string]$Actor = 'Keeper Tristan'
+    )
+
+    if (-not $Capability) {
+        Write-Host '❌ Missing capability env var.' -ForegroundColor Red
+        return
+    }
+
+    $endpoint = switch ($Type) {
+        'pr' { 'broadcast-pr' }
+        'gist' { 'broadcast-gist' }
+        'netlify' { 'broadcast-netlify' }
+        'discord' { 'broadcast-discord' }
+        'gemini' { 'gemini-generate' }
+    }
+
+    $uri = "$BaseUrl/$endpoint"
+    $json = $Payload | ConvertTo-Json -Depth 6
+
+    Write-Host "📡 $Type → $uri" -ForegroundColor Cyan
+
+    try {
+        $res = Invoke-WebRequest -Uri $uri -Method POST -Headers @{
+            'x-codex-capability' = $Capability
+            'x-codex-actor' = $Actor
+            'Content-Type' = 'application/json'
+        } -Body $json
+
+        Write-Host "✅ Status: $($res.StatusCode)" -ForegroundColor Green
+        Write-Host $res.Content
+    }
+    catch {
+        Write-Host "❌ Broadcast failed: $($_.Exception.Message)" -ForegroundColor Red
+        if ($_.Exception.Response -and $_.Exception.Response.ContentLength -gt 0) {
+            $_.Exception.Response.GetResponseStream() | % {
+                $reader = New-Object System.IO.StreamReader($_)
+                Write-Host ($reader.ReadToEnd())
+                $reader.Dispose()
+            }
+        }
+    }
+}
+
+Export-ModuleMember -Function Invoke-CodexBroadcast

--- a/scrolls/rituals.md
+++ b/scrolls/rituals.md
@@ -16,6 +16,10 @@ A centralized registry for operational rituals in the Beehive repository. Every 
 - **File:** `.github/post-merge-checklist.md`
 - **Purpose:** Guides verification of deployments, dashboard integrity, and documentation after every merge.
 
+## 🟢 Codex Broadcast Ritual
+- **File:** `scripts/powershell/Codex.psm1`
+- **Purpose:** Issues PR, Gist, Netlify, or Discord broadcasts while inscribing mutation logs with actor headers.
+
 ---
 
 **How to use:**  

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,15 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "codex_mutations",
+    "version": "1.5.0",
+    "enabled": true
+  },
+  {
+    "name": "mutation_feed",
+    "version": "1.5.0",
+    "enabled": true
   }
 ]

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -1,6 +1,7 @@
-import SentimentCard from '@/components/SentimentCard';
 import LineageCard from '@/components/LineageCard';
 import SentimentHistogram from '@/components/SentimentHistogram';
+import MutationFeedClient from '@/components/MutationFeedClient';
+import SentimentCard from '@/components/SentimentCard';
 
 export default function AnalyticsPage() {
   return (
@@ -11,6 +12,7 @@ export default function AnalyticsPage() {
         <LineageCard />
       </div>
       <SentimentHistogram hours={24} />
+      <MutationFeedClient />
     </main>
   );
 }

--- a/src/components/MutationFeed.tsx
+++ b/src/components/MutationFeed.tsx
@@ -1,0 +1,68 @@
+export type Mutation = {
+  id: string;
+  created_at: string;
+  actor: string;
+  ritual: string;
+  target?: string | null;
+  status: string;
+  message: string;
+};
+
+const BADGE_BASE = 'text-xs px-2 py-0.5 rounded-full border uppercase tracking-wide';
+
+function statusBadge(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === 'success') {
+    return `${BADGE_BASE} bg-emerald-500/10 text-emerald-300 border-emerald-500/40`;
+  }
+  if (normalized === 'failure') {
+    return `${BADGE_BASE} bg-rose-500/10 text-rose-300 border-rose-500/40`;
+  }
+  return `${BADGE_BASE} bg-slate-500/10 text-slate-200 border-slate-600/40`;
+}
+
+export default function MutationFeed({ items }: { items: Mutation[] }) {
+  if (!items.length) {
+    return (
+      <section className="max-w-6xl mx-auto p-6">
+        <h2 className="text-2xl font-bold text-white mb-4">Live mutation feed</h2>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/80 p-6 text-slate-400">
+          Awaiting the first ritual echo.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="max-w-6xl mx-auto p-6">
+      <h2 className="text-2xl font-bold text-white mb-4">Live mutation feed</h2>
+      <div className="space-y-3">
+        {items.map((m) => (
+          <article
+            key={m.id}
+            className="p-4 rounded-xl border border-slate-800 bg-slate-900/80 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between"
+          >
+            <div className="space-y-1">
+              <div className="text-slate-400 text-xs">
+                {new Date(m.created_at).toLocaleString()}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="text-white font-semibold">{m.ritual}</div>
+                <span className={statusBadge(m.status)}>
+                  {m.status}
+                </span>
+              </div>
+              <div className="text-slate-200 text-sm">{m.message}</div>
+              {m.target ? (
+                <div className="text-slate-400 text-xs break-all">
+                  Target: {m.target}
+                </div>
+              ) : null}
+            </div>
+            <div className="text-slate-400 text-sm sm:text-right">{m.actor}</div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/MutationFeedClient.tsx
+++ b/src/components/MutationFeedClient.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import MutationFeed, { type Mutation } from './MutationFeed';
+import { loadMutations } from '@/lib/loadMutations';
+
+export default function MutationFeedClient({ pollMs = 15000 }: { pollMs?: number }) {
+  const [items, setItems] = useState<Mutation[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function refresh() {
+      try {
+        const data = await loadMutations();
+        if (!cancelled) {
+          setItems(data);
+          setError(null);
+          setLoading(false);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      }
+    }
+
+    refresh();
+    if (pollMs > 0) {
+      timer = setInterval(refresh, pollMs);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [pollMs]);
+
+  if (error) {
+    return (
+      <section className="max-w-6xl mx-auto p-6">
+        <h2 className="text-2xl font-bold text-white mb-4">Live mutation feed</h2>
+        <div className="rounded-xl border border-rose-900 bg-rose-950/70 p-6 text-rose-200">
+          Ritual feed error: {error}
+        </div>
+      </section>
+    );
+  }
+
+  if (loading) {
+    return (
+      <section className="max-w-6xl mx-auto p-6">
+        <h2 className="text-2xl font-bold text-white mb-4">Live mutation feed</h2>
+        <div className="rounded-xl border border-slate-800 bg-slate-900/80 p-6 text-slate-400">
+          Listening for lineage whispers…
+        </div>
+      </section>
+    );
+  }
+
+  return <MutationFeed items={items} />;
+}

--- a/src/lib/loadMutations.ts
+++ b/src/lib/loadMutations.ts
@@ -1,0 +1,18 @@
+import type { Mutation } from '@/components/MutationFeed';
+
+const capability = process.env.NEXT_PUBLIC_CODEX_CAPABILITY ?? '';
+
+export async function loadMutations(): Promise<Mutation[]> {
+  const res = await fetch('/.netlify/functions/mutations', {
+    method: 'GET',
+    headers: { 'x-codex-capability': capability },
+    cache: 'no-store',
+  });
+
+  if (!res.ok) {
+    throw new Error(`Mutation fetch failed: ${res.status}`);
+  }
+
+  const json = (await res.json()) as Mutation[];
+  return Array.isArray(json) ? json : [];
+}

--- a/supabase/sql/2025-10-22_mutations.sql
+++ b/supabase/sql/2025-10-22_mutations.sql
@@ -1,0 +1,16 @@
+-- codex_mutations: immutable event log
+create table if not exists public.codex_mutations (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  actor text not null,
+  ritual text not null,
+  target text,
+  status text not null,
+  message text,
+  payload jsonb,
+  response jsonb
+);
+
+create index if not exists idx_codex_mutations_created_at on public.codex_mutations (created_at desc);
+create index if not exists idx_codex_mutations_ritual on public.codex_mutations (ritual);
+create index if not exists idx_codex_mutations_status on public.codex_mutations (status);


### PR DESCRIPTION
## Summary
- inscribe the `codex_mutations` Supabase ledger and shared Netlify logger for ritual telemetry
- bind PR, gist, Netlify, and Discord broadcasts to the ledger and expose a secured mutations feed function
- stream the mutation feed onto the analytics dashboard, register new scrolls, and ship a PowerShell broadcast ritual

## Testing
- not run (project scripts unavailable)

------
https://chatgpt.com/codex/tasks/task_b_68f7c9b9413c832e993edb19c21bea76