### PR TITLE
Add Codex broadcast relays and Gemini gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+- Netlify broadcast relays for GitHub PRs, Gists, Discord, Netlify build hooks, and Gemini gateway, with dashboard buttons and PowerShell helpers.
 ## v1.4.5 — Remix Scheduler (2025-10-19)
 
 ### Codex Helpers

--- a/Codex.psm1
+++ b/Codex.psm1
@@ -1,0 +1,65 @@
+function Invoke-CodexBroadcast {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('pr', 'gist', 'netlify', 'discord')]
+        [string] $Type,
+
+        [hashtable] $Payload = @{},
+
+        [string] $BaseUrl = 'https://your-site.netlify.app/.netlify/functions',
+
+        [string] $Capability = $env:CODEX_CAPABILITY
+    )
+
+    if (-not $Capability) {
+        Write-Host '❌ Missing capability. Set CODEX_CAPABILITY env var.' -ForegroundColor Red
+        return
+    }
+
+    $endpoint = switch ($Type) {
+        'pr' { 'broadcast-pr' }
+        'gist' { 'broadcast-gist' }
+        'netlify' { 'broadcast-netlify' }
+        'discord' { 'broadcast-discord' }
+    }
+
+    $uri = "$BaseUrl/$endpoint"
+    $json = ($Payload | ConvertTo-Json -Depth 6)
+
+    Write-Host "📡 Broadcasting $Type → $uri" -ForegroundColor Cyan
+    $res = Invoke-WebRequest -Uri $uri -Method POST -Headers @{ 'x-codex-capability' = $Capability; 'Content-Type' = 'application/json' } -Body $json
+    Write-Host "✅ Status: $($res.StatusCode)" -ForegroundColor Green
+    Write-Host $res.Content
+}
+
+function Invoke-GeminiScroll {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Prompt,
+
+        [string] $Model = 'gemini-2.5-flash',
+
+        [string] $BaseUrl = 'https://your-site.netlify.app/.netlify/functions/gemini-generate',
+
+        [string] $Capability = $env:CODEX_CAPABILITY
+    )
+
+    if (-not $Capability) {
+        Write-Host '❌ Missing capability. Set CODEX_CAPABILITY env var.' -ForegroundColor Red
+        return
+    }
+
+    $payload = @{ prompt = $Prompt; model = $Model } | ConvertTo-Json
+    Write-Host "🔮 Summoning Gemini ($Model)" -ForegroundColor Magenta
+    $res = Invoke-WebRequest -Uri $BaseUrl -Method POST -Headers @{ 'x-codex-capability' = $Capability; 'Content-Type' = 'application/json' } -Body $payload
+    $obj = $res.Content | ConvertFrom-Json
+    Write-Host "✅ Status: $($res.StatusCode)" -ForegroundColor Green
+    if ($obj.text) {
+        Write-Host '🔮 Gemini says:' -ForegroundColor Yellow
+        Write-Host $obj.text -ForegroundColor Yellow
+    } else {
+        Write-Host $res.Content
+    }
+}

--- a/netlify/functions/_shared/http.ts
+++ b/netlify/functions/_shared/http.ts
@@ -1,0 +1,133 @@
+import type { HandlerEvent, HandlerResponse } from '@netlify/functions';
+import { Buffer } from 'node:buffer';
+
+type JsonResult<T> = { ok: true; data: T } | { ok: false; error: HandlerResponse };
+
+function capabilityHeader(event: HandlerEvent) {
+  const headers = event.headers || {};
+  return (
+    (headers['x-codex-capability'] as string | undefined) ??
+    (headers['X-Codex-Capability'] as string | undefined)
+  );
+}
+
+export function methodNotAllowed(allowed: string | string[]): HandlerResponse {
+  const value = Array.isArray(allowed) ? allowed.join(', ') : allowed;
+  return {
+    statusCode: 405,
+    headers: { Allow: value },
+    body: 'Method not allowed',
+  };
+}
+
+export function jsonResponse(statusCode: number, body: unknown): HandlerResponse {
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  };
+}
+
+export function missingConfig(name: string): HandlerResponse {
+  return jsonResponse(500, {
+    ok: false,
+    error: `Missing configuration: ${name}`,
+  });
+}
+
+export function requireCapability(
+  event: HandlerEvent,
+  key: string | undefined
+): HandlerResponse | null {
+  if (!key) {
+    return missingConfig('CODEX_CAPABILITY_KEY');
+  }
+
+  const provided = capabilityHeader(event);
+  if (provided !== key) {
+    return jsonResponse(401, { ok: false, error: 'Unauthorized' });
+  }
+  return null;
+}
+
+function decodeBody(event: HandlerEvent): string {
+  if (!event.body) return '';
+  return event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64').toString('utf8')
+    : event.body;
+}
+
+export function parseJsonBody<T = Record<string, unknown>>(
+  event: HandlerEvent
+): JsonResult<T> {
+  const raw = decodeBody(event);
+  if (!raw) {
+    return { ok: true, data: {} as T };
+  }
+
+  try {
+    return { ok: true, data: JSON.parse(raw) as T };
+  } catch {
+    return {
+      ok: false,
+      error: jsonResponse(400, { ok: false, error: 'Invalid JSON body' }),
+    };
+  }
+}
+
+type FetchResponse = globalThis.Response;
+
+type ExtractedResponse = {
+  ok: boolean;
+  status: number;
+  sizeBytes: number;
+  requestId: string | null;
+  data: unknown;
+  raw: string;
+};
+
+export async function extractResponse(res: FetchResponse): Promise<ExtractedResponse> {
+  const raw = await res.text();
+  let data: unknown = null;
+  if (raw) {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      data = raw;
+    }
+  }
+
+  const requestId =
+    res.headers.get('x-request-id') ??
+    res.headers.get('x-github-request-id') ??
+    res.headers.get('x-nf-request-id') ??
+    res.headers.get('x-amzn-requestid') ??
+    res.headers.get('x-amzn-trace-id');
+
+  return {
+    ok: res.ok,
+    status: res.status,
+    sizeBytes: Buffer.byteLength(raw, 'utf8'),
+    requestId,
+    data,
+    raw,
+  };
+}
+
+export async function relayResponse(
+  target: string,
+  res: FetchResponse,
+  meta: Record<string, unknown> = {}
+): Promise<HandlerResponse> {
+  const extracted = await extractResponse(res);
+  return jsonResponse(extracted.status, {
+    ok: extracted.ok,
+    status: extracted.status,
+    target,
+    forwardedAt: new Date().toISOString(),
+    sizeBytes: extracted.sizeBytes,
+    requestId: extracted.requestId,
+    data: extracted.data,
+    ...meta,
+  });
+}

--- a/netlify/functions/broadcast-discord.ts
+++ b/netlify/functions/broadcast-discord.ts
@@ -1,0 +1,53 @@
+import type { Handler } from '@netlify/functions';
+
+import {
+  jsonResponse,
+  methodNotAllowed,
+  missingConfig,
+  parseJsonBody,
+  relayResponse,
+  requireCapability,
+} from './_shared/http';
+
+type DiscordPayload = {
+  message?: string;
+};
+
+const CAPABILITY = process.env.CODEX_CAPABILITY_KEY;
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return methodNotAllowed('POST');
+  }
+
+  const auth = requireCapability(event, CAPABILITY);
+  if (auth) return auth;
+
+  if (!DISCORD_WEBHOOK_URL) {
+    return missingConfig('DISCORD_WEBHOOK_URL');
+  }
+
+  const parsed = parseJsonBody<DiscordPayload>(event);
+  if (!parsed.ok) return parsed.error;
+
+  const message = parsed.data.message ?? 'Codex broadcast';
+
+  try {
+    const res = await fetch(DISCORD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: message }),
+    });
+
+    return await relayResponse('discord.webhook', res, { message });
+  } catch (error) {
+    const messageText =
+      error instanceof Error ? error.message : 'Discord webhook request failed';
+    return jsonResponse(502, {
+      ok: false,
+      target: 'discord.webhook',
+      error: messageText,
+    });
+  }
+};

--- a/netlify/functions/broadcast-gist.ts
+++ b/netlify/functions/broadcast-gist.ts
@@ -1,0 +1,79 @@
+import type { Handler } from '@netlify/functions';
+
+import {
+  jsonResponse,
+  methodNotAllowed,
+  missingConfig,
+  parseJsonBody,
+  relayResponse,
+  requireCapability,
+} from './_shared/http';
+
+type GistPayload = {
+  filename?: string;
+  content?: string;
+  description?: string;
+  public?: boolean;
+};
+
+const CAPABILITY = process.env.CODEX_CAPABILITY_KEY;
+const GITHUB_TOKEN = process.env.GITHUB_PAT;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return methodNotAllowed('POST');
+  }
+
+  const auth = requireCapability(event, CAPABILITY);
+  if (auth) return auth;
+
+  if (!GITHUB_TOKEN) {
+    return missingConfig('GITHUB_PAT');
+  }
+
+  const parsed = parseJsonBody<GistPayload>(event);
+  if (!parsed.ok) return parsed.error;
+
+  const {
+    filename,
+    content,
+    description = 'Codex scroll',
+    public: isPublic = false,
+  } = parsed.data;
+
+  if (!filename || !content) {
+    return jsonResponse(400, {
+      ok: false,
+      error: 'Missing filename or content',
+    });
+  }
+
+  try {
+    const res = await fetch('https://api.github.com/gists', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({
+        description,
+        public: isPublic,
+        files: { [filename]: { content } },
+      }),
+    });
+
+    return await relayResponse('github.gist', res, {
+      description,
+      public: isPublic,
+      filename,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'GitHub request failed';
+    return jsonResponse(502, {
+      ok: false,
+      target: 'github.gist',
+      error: message,
+    });
+  }
+};

--- a/netlify/functions/broadcast-netlify.ts
+++ b/netlify/functions/broadcast-netlify.ts
@@ -1,0 +1,39 @@
+import type { Handler } from '@netlify/functions';
+
+import {
+  jsonResponse,
+  methodNotAllowed,
+  missingConfig,
+  relayResponse,
+  requireCapability,
+} from './_shared/http';
+
+const CAPABILITY = process.env.CODEX_CAPABILITY_KEY;
+const BUILD_HOOK = process.env.NETLIFY_BUILD_HOOK_URL;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return methodNotAllowed('POST');
+  }
+
+  const auth = requireCapability(event, CAPABILITY);
+  if (auth) return auth;
+
+  if (!BUILD_HOOK) {
+    return missingConfig('NETLIFY_BUILD_HOOK_URL');
+  }
+
+  try {
+    const res = await fetch(BUILD_HOOK, { method: 'POST' });
+    return await relayResponse('netlify.build_hook', res, {
+      hook: BUILD_HOOK,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Netlify request failed';
+    return jsonResponse(502, {
+      ok: false,
+      target: 'netlify.build_hook',
+      error: message,
+    });
+  }
+};

--- a/netlify/functions/broadcast-pr.ts
+++ b/netlify/functions/broadcast-pr.ts
@@ -1,0 +1,69 @@
+import type { Handler } from '@netlify/functions';
+
+import {
+  jsonResponse,
+  methodNotAllowed,
+  missingConfig,
+  parseJsonBody,
+  relayResponse,
+  requireCapability,
+} from './_shared/http';
+
+type PullPayload = {
+  title?: string;
+  body?: string;
+  base?: string;
+  head?: string;
+};
+
+const CAPABILITY = process.env.CODEX_CAPABILITY_KEY;
+const GITHUB_TOKEN = process.env.GITHUB_PAT;
+const GITHUB_REPO = process.env.GITHUB_REPO;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return methodNotAllowed('POST');
+  }
+
+  const auth = requireCapability(event, CAPABILITY);
+  if (auth) return auth;
+
+  if (!GITHUB_TOKEN) {
+    return missingConfig('GITHUB_PAT');
+  }
+  if (!GITHUB_REPO) {
+    return missingConfig('GITHUB_REPO');
+  }
+
+  const parsed = parseJsonBody<PullPayload>(event);
+  if (!parsed.ok) return parsed.error;
+
+  const { title, body, base = 'main', head } = parsed.data;
+  if (!head) {
+    return jsonResponse(400, { ok: false, error: "Missing 'head' branch" });
+  }
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/pulls`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/vnd.github+json',
+      },
+      body: JSON.stringify({ title, body, base, head }),
+    });
+
+    return await relayResponse('github.pull_request', res, {
+      repo: GITHUB_REPO,
+      branch: { base, head },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'GitHub request failed';
+    return jsonResponse(502, {
+      ok: false,
+      target: 'github.pull_request',
+      error: message,
+    });
+  }
+};

--- a/netlify/functions/gemini-generate.ts
+++ b/netlify/functions/gemini-generate.ts
@@ -1,0 +1,102 @@
+import type { Handler } from '@netlify/functions';
+
+import {
+  extractResponse,
+  jsonResponse,
+  methodNotAllowed,
+  missingConfig,
+  parseJsonBody,
+  requireCapability,
+} from './_shared/http';
+
+type GeminiPayload = {
+  prompt?: string;
+  model?: string;
+};
+
+const CAPABILITY = process.env.CODEX_CAPABILITY_KEY;
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return methodNotAllowed('POST');
+  }
+
+  const auth = requireCapability(event, CAPABILITY);
+  if (auth) return auth;
+
+  if (!GEMINI_API_KEY) {
+    return missingConfig('GEMINI_API_KEY');
+  }
+
+  const parsed = parseJsonBody<GeminiPayload>(event);
+  if (!parsed.ok) return parsed.error;
+
+  const prompt = parsed.data.prompt?.trim();
+  const model = parsed.data.model?.trim() || 'gemini-2.5-flash';
+
+  if (!prompt) {
+    return jsonResponse(400, { ok: false, error: 'Missing prompt' });
+  }
+
+  try {
+    const res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${GEMINI_API_KEY}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: prompt }] }],
+        }),
+      }
+    );
+
+    const summary = await extractResponse(res);
+    if (!summary.ok) {
+      const errorMessage =
+        (summary.data as any)?.error?.message || 'Gemini request failed';
+      return jsonResponse(summary.status, {
+        ok: false,
+        target: 'google.gemini',
+        status: summary.status,
+        error: errorMessage,
+        sizeBytes: summary.sizeBytes,
+        requestId: summary.requestId,
+        model,
+        data: summary.data,
+      });
+    }
+
+    const text = extractGeminiText(summary.data);
+    return jsonResponse(200, {
+      ok: true,
+      target: 'google.gemini',
+      status: summary.status,
+      forwardedAt: new Date().toISOString(),
+      sizeBytes: summary.sizeBytes,
+      requestId: summary.requestId,
+      model,
+      text,
+      data: summary.data,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Gemini request failed';
+    return jsonResponse(502, {
+      ok: false,
+      target: 'google.gemini',
+      error: message,
+    });
+  }
+};
+
+function extractGeminiText(data: unknown): string {
+  if (!data || typeof data !== 'object') return '';
+  const candidate = (data as any)?.candidates?.[0];
+  if (!candidate) return '';
+  const parts = candidate?.content?.parts;
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .map((part: any) => (typeof part?.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n');
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,5 @@
+import BroadcastActions from '../src/components/BroadcastActions';
+
 export default function Home() {
   return (
     <main style={{ padding: 24, fontFamily: 'system-ui' }}>
@@ -8,6 +10,7 @@ export default function Home() {
         <li><a href="/.netlify/functions/ritual-ping">ritual-ping</a></li>
         <li><a href="/.netlify/functions/ritual-metrics">ritual-metrics</a></li>
       </ul>
+      <BroadcastActions />
     </main>
   );
 }

--- a/scrolls/broadcast_relays.md
+++ b/scrolls/broadcast_relays.md
@@ -1,0 +1,43 @@
+# Broadcast Relays — Codex Lineage
+
+This scroll documents the broadcast rituals introduced for the Beehive swarm. Each relay is sealed as a Netlify Function and authenticated via the shared capability key.
+
+## Functions
+
+| Function | Target | Notes |
+| --- | --- | --- |
+| `broadcast-pr` | GitHub Pull Requests | Creates a pull request for the configured repository. |
+| `broadcast-gist` | GitHub Gists | Publishes or updates an authenticated Gist. |
+| `broadcast-netlify` | Netlify Build Hook | Triggers the configured build hook for digest generation. |
+| `broadcast-discord` | Discord | Posts a message to the configured webhook. |
+| `gemini-generate` | Google AI Studio | Requests text completions from Gemini models. |
+
+All functions expect the header `x-codex-capability` to match `CODEX_CAPABILITY_KEY` and surface metadata such as status, requestId, and payload size for audit overlays.
+
+## Dashboard Ritual
+
+`src/components/BroadcastActions.tsx` renders trigger buttons on the home page, letting custodians launch each broadcast from the dashboard. Every action replays the response payload so the lineage is observable.
+
+## PowerShell Helpers
+
+`Codex.psm1` exposes:
+
+- `Invoke-CodexBroadcast` — wraps the HTTP calls for PR/Gist/Netlify/Discord.
+- `Invoke-GeminiScroll` — simplifies Gemini prompts with status reporting.
+
+Both commands require `$env:CODEX_CAPABILITY` and default to the production Netlify endpoints.
+
+## Configuration
+
+Set these environment variables in Netlify:
+
+- `CODEX_CAPABILITY_KEY`
+- `GITHUB_PAT`
+- `GITHUB_REPO`
+- `NETLIFY_BUILD_HOOK_URL`
+- `DISCORD_WEBHOOK_URL`
+- `GEMINI_API_KEY`
+
+Local operators should export `CODEX_CAPABILITY` before running the PowerShell helpers.
+
+> Every broadcast is now a traceable chord in the Codex lineage.

--- a/scrolls/rituals.md
+++ b/scrolls/rituals.md
@@ -16,10 +16,14 @@ A centralized registry for operational rituals in the Beehive repository. Every 
 - **File:** `.github/post-merge-checklist.md`
 - **Purpose:** Guides verification of deployments, dashboard integrity, and documentation after every merge.
 
+## 🟡 Broadcast Relays
+- **File:** `scrolls/broadcast_relays.md`
+- **Purpose:** Details the Netlify broadcast functions, dashboard triggers, and PowerShell helpers for Codex rituals.
+
 ---
 
-**How to use:**  
-- Review this index before every PR or milestone.  
+**How to use:**
+- Review this index before every PR or milestone.
 - Follow the linked rituals for consistent, audit-ready operations.  
 - Update this index when new ritual scrolls are added.
 

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "broadcast_relays",
+    "version": "1.0.0-draft",
+    "enabled": true
   }
 ]

--- a/src/components/BroadcastActions.tsx
+++ b/src/components/BroadcastActions.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+type Payload = Record<string, unknown>;
+
+const CAPABILITY = process.env.NEXT_PUBLIC_CODEX_CAPABILITY ?? '';
+
+async function invokeBroadcast(path: string, payload: Payload) {
+  if (!CAPABILITY) {
+    throw new Error('Missing NEXT_PUBLIC_CODEX_CAPABILITY');
+  }
+
+  const res = await fetch(`/.netlify/functions/${path}`, {
+    method: 'POST',
+    headers: {
+      'x-codex-capability': CAPABILITY,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    const truncated = text.length > 300 ? `${text.slice(0, 300)}…` : text;
+    throw new Error(`Failed (${res.status}): ${truncated}`);
+  }
+
+  return text;
+}
+
+export default function BroadcastActions() {
+  const notify = async (path: string, payload: Payload) => {
+    try {
+      const text = await invokeBroadcast(path, payload);
+      const message = text ? `Broadcast sent.\n${text}` : 'Broadcast sent.';
+      window.alert(message);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Broadcast failed unexpectedly';
+      window.alert(message);
+    }
+  };
+
+  return (
+    <section className="max-w-6xl mx-auto p-6 flex flex-wrap gap-4">
+      <button
+        type="button"
+        className="px-4 py-2 rounded bg-blue-600 text-white"
+        onClick={() =>
+          notify('broadcast-pr', {
+            title: '🧬 Codex Mutation sealed',
+            body: 'Preservation Wave — sealed and broadcasted.',
+            base: 'main',
+            head: 'feature/preservation-wave',
+          })
+        }
+      >
+        Create PR
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 rounded bg-purple-600 text-white"
+        onClick={() =>
+          notify('broadcast-gist', {
+            filename: 'codex.yml',
+            content: '…paste your codex.yml content here…',
+            description: 'Main Codex manifest',
+            public: true,
+          })
+        }
+      >
+        Publish Gist
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 rounded bg-emerald-600 text-white"
+        onClick={() => notify('broadcast-netlify', {})}
+      >
+        Trigger Netlify Digest
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 rounded bg-slate-700 text-white"
+        onClick={() =>
+          notify('broadcast-discord', {
+            message: '📣 Codex: Preservation Wave sealed.',
+          })
+        }
+      >
+        Discord Broadcast
+      </button>
+      <button
+        type="button"
+        className="px-4 py-2 rounded bg-amber-600 text-white"
+        onClick={() =>
+          notify('gemini-generate', {
+            prompt: 'Write 5 ad hooks for a skincare launch in French and English.',
+            model: 'gemini-2.5-flash',
+          })
+        }
+      >
+        Gemini Scroll
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add shared Netlify helpers plus PR, gist, Netlify, Discord, and Gemini broadcast functions guarded by capability keys
- expose dashboard broadcast buttons and PowerShell helpers for triggering each ritual
- document the new lineage in the changelog and scroll registry

## Testing
- not run (no package scripts present)

------
https://chatgpt.com/codex/tasks/task_b_68f7c960c8c0832eada07b4cdbbc6010