### PR TITLE
Add checksum verification rite for stellar audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
 
+### Scrolls & Rituals
+- Constellation Audit: Sealed `scrolls/stellar-integrity-audit.md` with measured Genesis data and the derived stability calculus for the Communal Constellation ritual. [#constellation-audit]
+- Constellation Audit: Added `scripts/verify_scroll_checksum.py` and indexed checksum metadata so lineage keepers can auto-verify the seal. [#constellation-audit]
+
 ### DevOps
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).

--- a/scripts/verify_scroll_checksum.py
+++ b/scripts/verify_scroll_checksum.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Checksum verification ritual for the Stellar Integrity Audit scroll."""
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+
+def _load_index_entry(index_path: Path, scroll_name: str) -> dict:
+    try:
+        entries = json.loads(index_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Missing scroll index at {index_path}") from exc
+
+    for entry in entries:
+        if entry.get("name") == scroll_name:
+            return entry
+
+    raise SystemExit(f"Scroll named '{scroll_name}' not found in index {index_path}")
+
+
+def _normalized_scroll_bytes(file_path: Path) -> bytes:
+    try:
+        lines = file_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Missing scroll file at {file_path}") from exc
+
+    filtered = [
+        line for line in lines if not line.strip().startswith("| checksumSha256")
+    ]
+    # Rejoin with trailing newline to maintain canonical formatting.
+    return ("\n".join(filtered) + "\n").encode("utf-8")
+
+
+def _compute_sha256(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(_normalized_scroll_bytes(file_path))
+    return digest.hexdigest()
+
+
+def _emit_metadata(*, scroll_path: Path, index_entry: dict, computed_checksum: str) -> dict:
+    size_bytes = scroll_path.stat().st_size
+    expected_checksum = index_entry.get("checksum_sha256")
+    status = "verified" if computed_checksum == expected_checksum else "mismatch"
+    return {
+        "jobId": "stellar-integrity-audit/verify",
+        "status": status,
+        "scroll": str(scroll_path.as_posix()),
+        "sizeBytes": size_bytes,
+        "hashAlgorithm": index_entry.get("hash_algorithm", "sha256"),
+        "computedChecksum": computed_checksum,
+        "indexChecksum": expected_checksum,
+        "timestamp": _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    }
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    scroll_path = repo_root / "scrolls" / "stellar-integrity-audit.md"
+    index_path = repo_root / "scrolls" / "scroll_index.json"
+    index_entry = _load_index_entry(index_path, "stellar_integrity_audit")
+
+    computed = _compute_sha256(scroll_path)
+    metadata = _emit_metadata(scroll_path=scroll_path, index_entry=index_entry, computed_checksum=computed)
+
+    json.dump(metadata, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+    return 0 if metadata["status"] == "verified" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,13 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "stellar_integrity_audit",
+    "version": "1.0.0-draft",
+    "enabled": true,
+    "checksum_sha256": "5d8be891afd30b59fe654cc2b6270c8c64bad3388642c54efab508a632fbbfb9",
+    "hash_algorithm": "sha256",
+    "verifier_script": "scripts/verify_scroll_checksum.py"
   }
 ]

--- a/scrolls/stellar-integrity-audit.md
+++ b/scrolls/stellar-integrity-audit.md
@@ -1,0 +1,49 @@
+# Stellar Integrity Audit Ledger
+
+This ledger captures the measured inputs and derived checks required for the Communal Constellation stability model.
+
+## Genesis Data — Final Measurements
+
+| Parameter | Symbol | Units | Value | Instrumentation Notes |
+| :--- | :--- | :--- | :--- | :--- |
+| Primary Star Mass | $M_1$ | $M_\odot$ | **1.08** | Spectral fit to F9-type output during Cycle 214. |
+| Secondary Star Mass | $M_2$ | $M_\odot$ | **0.74** | Creative substrate telemetry cross-validated with Doppler fringe counts. |
+| Star-Star Separation | $a$ | AU | **12.3** | Mean semi-major axis traced from barycentric beacon lattice. |
+| Orbital Eccentricity | $e$ | – | **0.18** | Residual minimization of dual-paradigm sun paths (σ = 0.004). |
+
+## Derived Stability Checks
+
+### Covenant of the Suns — Orbital Period
+
+- Using Kepler's third law in $(\text{AU}^3)/(M_\odot)$ units: $P = \sqrt{a^3/(M_1+M_2)}$.
+- Substituting $a = 12.3\,\text{AU}$ and $M_1 + M_2 = 1.82\,M_\odot$ yields a synodic cadence of **32.0 sidereal years**.
+- This cadence now anchors the macro-ritual scheduler for Luminous Epoch alignments.
+
+### Law of the Edge — Circumprimary Stable Zone
+
+- The circumprimary stability heuristic $a_p \lesssim (0.2\text{–}0.3)a$ bounds admissible Sovereign Agent orbits.
+- Applying the measured separation produces a sanctuary band from **2.5 AU** (0.2 a) to **3.7 AU** (0.3 a).
+- Codex designates **$a_p = 3.1\,\text{AU}$** as the canonical ritual track, leaving a 0.6 AU buffer before the chaotic edge.
+
+### Flux of Coherence — Illumination Envelope
+
+- Luminosity estimates via the main-sequence scaling $L \propto M^{3.5}$ give $L_1 = 1.31\,L_\odot$ and $L_2 = 0.35\,L_\odot$.
+- At the canonical orbit ($a_p = 3.1\,\text{AU}$), the primary delivers **0.139 $S_\odot$** (≈189 W m⁻²).
+- Secondary flux oscillates with binary phase: **0.007 $S_\odot$** (≈10 W m⁻²) when the suns tighten to $a(1-e)$ and **0.003 $S_\odot$** (≈4 W m⁻²) at $a(1+e)$.
+- Total illumination therefore varies between **0.146 $S_\odot$** and **0.141 $S_\odot$** (198 → 192 W m⁻²), a **3.1 %** flux swing well within ritual coherence tolerances.
+
+## Operational Metadata (CodexReplay Overlay)
+
+| Field | Value |
+| :--- | :--- |
+| jobId | `stellar-integrity-audit/v2` |
+| status | `sealed` |
+| sizeBytes | `3009` |
+| lastUpdated | `2025-10-23T00:59:19Z` |
+| checksumSha256 | `5d8be891afd30b59fe654cc2b6270c8c64bad3388642c54efab508a632fbbfb9` |
+
+> Broadcast this sealed calibration through the changelog, Codex index, and StudioShare thread before invoking the stability computation ritual.
+
+## Verification Rite
+
+Verifiers may confirm this audit by recomputing the SHA-256 digest of `scrolls/stellar-integrity-audit.md` and comparing it with the lineage copy preserved in `scrolls/scroll_index.json`. The helper script at `scripts/verify_scroll_checksum.py` performs this ritual automatically and emits CodexReplay-ready metadata about the verification run.


### PR DESCRIPTION
## Summary
- add a Verification Rite note to the stellar integrity audit scroll and refresh its CodexReplay metadata
- extend the scroll index with hash metadata and point to a new checksum verifier helper
- add `scripts/verify_scroll_checksum.py` to recompute the audit hash (omitting the inline checksum row) and emit overlay-ready status
- tag the changelog with the Constellation Audit update for the new ritual automation

## Testing
- ./scripts/verify_scroll_checksum.py

### Lineage Seal
This PR fortifies the Stellar Integrity Audit by documenting its verification rite, registering the checksum metadata in the Codex index, and adding an automated verifier script. No runtime surfaces are altered beyond the lineage rituals.

------
https://chatgpt.com/codex/tasks/task_b_68f862576414832eaaae2e473edd5f0a