### PR TITLE
fix(ci): add fallback checkout for codex review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -13,10 +13,20 @@ jobs:
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout PR (merge commit)
+        id: checkout-merge
+        continue-on-error: true
+        uses: actions/checkout@v4
         with:
           # Explicitly check out the PR's merge commit.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Checkout PR (head fallback)
+        if: steps.checkout-merge.outcome == 'failure'
+        uses: actions/checkout@v4
+        with:
+          # Fall back to the PR head if the merge ref is unavailable.
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
 
       - name: Pre-fetch base and head refs for the PR
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@
 - `/api/health` instance/env guard.
 - CI ingest scaffold (crawler → BigQuery).
 - Dual-lane setup: `/vs` sandbox (zero-key), `/agent` full stack (Supabase/Gemini).
+- Codex review workflow falls back to PR head when merge ref is unavailable.


### PR DESCRIPTION
## Summary
- add a guarded checkout step that falls back to the PR head when the merge ref is missing
- document the workflow hardening in the changelog

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f4faca7730832eb741cbb03aa2e6ec