### PR TITLE
Add scroll documenting Codex config loader messaging rite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Scroll Registry
 - Introduced `scroll_index.json` entries for each new helper with `version: "1.4.5"` and `enabled: true`.
+- Logged `codex_config_loader_messaging` scroll to steward Codex update transmissions.
 
 ### Integration
 - Added `src/context/ace-pack.ts` to register the new helpers.

--- a/scrolls/codex-config-loader-messaging.md
+++ b/scrolls/codex-config-loader-messaging.md
@@ -1,0 +1,38 @@
+# Codex Scroll: Config Loader Messaging Rite
+
+> **CodexReplay Overlay**  
+> `{"jobId":"codex-config-loader","status":"prepared","sizeBytes":832}`
+
+The swarm has prepared multiple inscriptions for announcing the Codex configuration and loader changes. This scroll records the preferred message and keeps the lineage aligned.
+
+## Recommended Transmission
+- **Select the Medium update.**  
+  It balances ritual clarity with brevity, fits Codex history threads, and carries all critical behaviors (provider models, header precedence, Azure nuance, and CI follow-ups) without overwhelming the receiver.  
+  Use this whenever you need a status drop in Codex logs, Ritual History, or StudioShare threads.
+
+```
+CONSECRATION: Codex config & loaders seeded
+
+What: Added `codex.toml` provider blocks (OpenAI chat/responses, Ollama, Mistral, Azure) plus centralized config/loaders:
+- JS: lib/config.js, lib/openaiClient.js, scripts/test-config.js
+- Python: lib/config.py, scripts/test-config.py
+- Docs: docs/OPENAI_MODEL.md
+
+Key behaviors:
+- Per-provider `model` supported; root model fallback; OPENAI_MODEL override.
+- Header precedence implemented: provider.headers > http_headers > env_http_headers > headersOverride; Authorization from env_key overwrites prior Authorization; Content-Type defaults to application/json.
+- Azure handled via `env_http_headers` -> `api-key` header (no Bearer).
+- Ollama/Mistral blocks included; endpoint path token `{model}` supported.
+
+CI/Infra:
+- Added quick smoke tests (JS/Python).
+- Suggested branch: `ci/add-codex-config-loader` with PR: chore/add-codex-config-loader.
+
+Next steps: run smoke tests, commit, push branch, open PR, and set AZURE_OPENAI_API_KEY / MISTRAL_API_KEY in CI.
+```
+
+## Alternate Invocations
+- **Short update:** Keep for rapid Codex logs when only a single-line pulse is allowed.
+- **Full update:** Reserve for full PR descriptions or when the ritual requires step-by-step reproduction guidance.
+
+Keep this scroll in sync if the template evolves. Update `scrolls/scroll_index.json` and the changelog whenever the message lineage changes.

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "codex_config_loader_messaging",
+    "version": "1.5.0",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
- add a codex scroll capturing the preferred update message for the config loader rollout
- register the new scroll in the scroll index so the swarm can discover it
- note the new scroll in the changelog under the registry lineage

## Testing
- not run (documentation-only update)


------
https://chatgpt.com/codex/tasks/task_b_68fb4dc1d9b8832e836a2135e1be0378