### PR TITLE
Fix Codex review checkout ref resilience

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Follow the head ref directly; merge refs can evaporate when PRs close or rebases stall.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- ensure the Codex review workflow checks out the pull request head from the correct repository by specifying the fork's full name

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_b_68fbbc23d3d4832eb053cc5d33a317e7