### PR TITLE
Fix Codex review checkout ref resilience

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Follow the head ref directly; merge refs can evaporate when PRs close or rebases stall.
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- ensure the Codex review workflow checks out the pull request head ref from the correct source repository so forked branches can be cloned

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_b_68fbbc07fe2c832eab020db1416ae880