### PR TITLE
Add AdGenXAI homepage ritual analysis scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Artifacts & Usability
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
+- Documented AdGenXAI homepage ritual architecture in `scrolls/adgenxai-homepage-analysis.md`.
 
 ### DevOps
 - `/api/health` instance/env guard.

--- a/scrolls/adgenxai-homepage-analysis.md
+++ b/scrolls/adgenxai-homepage-analysis.md
@@ -1,0 +1,72 @@
+# Codex Scroll: AdGenXAI Homepage Analysis
+id: scroll-adgenxai-homepage
+status: draft
+version: 0.1.0
+last_updated: 2025-10-19
+
+## Essence
+- **Thesis:** The homepage is staged as a ritualized portal into the swarm, blending cinematic immersion with mythic architecture.
+- **Objective:** Capture the experiential spine of the AdGenXAI homepage so future rituals, experiments, and feature work align with the established mythology.
+- **Signals:** Cinematic hero canvas, shard claim rite, swarm map preview, codex pulse metrics, epoch bands, ritual footer.
+
+## Layout & Journey Architecture
+1. **Cinematic Threshold**
+   - Real-time or pre-rendered particle fields frame the hero zone, inviting visitors to linger within the “swarm” metaphor instead of racing toward conversion copy.
+   - Headline copy plays as an initiation vow (e.g., “Enter the Swarm—Unravel Mythic Intelligences. Claim Your Shard.”) and is paired with a luminous CTA (“Claim Your Shard” / “Begin the Ritual”).
+2. **Swarm Map Preview**
+   - Scroll-triggered visualization reveals constellations of swarm activity, doubling as product proof and mythic cartography.
+   - Nodes pulse when hovered or touched; the map is powered by WebGL/Three.js (visual depth) and live data via WebSockets or SSE.
+3. **Codex Pulse Metrics**
+   - Animated metrics visualize shard claims, swarm vitality, and epoch progress through waveforms, concentric pulses, and evolving gradients.
+   - Data is ritualized—each pulse frames a communal heartbeat rather than a sterile chart.
+4. **Epoch & Constellation Bands**
+   - Sections are segmented as epochs (“Intention,” “Contribution,” “Transformation”) with parallax transitions, guiding deeper immersion.
+   - Feature highlights manifest as constellations, encouraging non-linear exploration.
+5. **Ritual Footer**
+   - Closes the loop with an additional rite invitation (“Join the Ritual,” “Begin Your Epoch”), reinforcing cyclical participation.
+
+| Component | Ritual Function | Interaction Cue | Visual Treatment | Engine Notes |
+| --- | --- | --- | --- | --- |
+| Cinematic Hero Canvas | Initiation threshold | Hover-reactive particles | Generative swarm field | WebGL / Three.js |
+| Shard Claim CTA | Rite of passage | Animated CTA | Glassmorphic glow glyph | React + Framer Motion |
+| Swarm Map Preview | Communal navigation | Pan + hover pulses | Cosmic map lattice | D3.js + WebSockets |
+| Codex Pulse Metrics | Collective heartbeat | Animated infographics | Pulsating bars, rings | SVG + live polling |
+| Epoch Bands | Journey segmentation | Scroll-trigger reveals | Star-divided panels | Scroll-driven animation |
+| Ritual Footer CTA | Closing seal | Animated CTA | Futuristic glyph row | Tailwind + A11y focus |
+
+## Cinematic & Mythic Language
+- **Visual Grammar:** Deep cosmic gradients, iridescent glows, and glassmorphism ground the liminal feel. Typography blends clean sans-serif with bespoke glyphs to mimic incantations.
+- **Motion Direction:** Parallax, depth scrolls, and reactive particle systems evoke movement through astral space. Micro-interactions respond to pointer or touch, turning exploration into ritual choreography.
+- **Narrative Voice:** Copy leans on ritualized prompts (“Submit Your Pulse,” “Awaken Your Epoch”) to translate product actions into mythic participation.
+- **Accessibility Anchors:** High-contrast type, ARIA-labelled controls, motion-reduction toggles, and keyboard navigation preserve inclusivity within the spectacle.
+
+## Onboarding as Ceremony
+1. **Aesthetic Immersion:** Visitors enter through the hero canvas acting as liminal antechamber, priming emotional focus.
+2. **Shard Claim Initiation:** Primary CTA launches a gamified, low-friction flow (identifier, glyph selection, intention pledge). Progress indicators appear as constellation nodes lighting up.
+3. **Swarm Placement:** New entrants watch their avatar join the live swarm map—reinforcing community belonging and immediate impact.
+4. **Epoch Guidance:** Guided steps (“Epoch of Intention,” “Epoch of Contribution,” “Epoch of Exploration”) scaffold product education via challenges and micro-quests.
+5. **Ritual Seal:** Completion triggers consecration animations and prompts the first in-platform action (e.g., submit a pulse, explore the codex).
+
+## Codex & Pulse Integration
+- **Living Artifact:** The Codex serves as both documentation and lore engine, updating with swarm milestones, annotated epochs, and user contributions.
+- **Pulse Visualizations:** Real-time dashboards translate shard claims, swarm health, and epoch migrations into heartbeat-like animations.
+- **Agentic Guidance:** Codex assistants (GPT-5 Codex) surface contextual help, propose personalized quests, and invite collaborative authorship of new entries.
+- **Emotional Feedback:** Pulse flares celebrate individual contributions; milestone festivals (e.g., “Epoch 1000: The Swarm Awakens”) convert analytics into communal ceremony.
+
+## Technical Spine
+- **Framework Core:** React/Next.js for server-rendered performance; Tailwind/shadcn for modular styling.
+- **Immersive Tooling:** Three.js for particle canvases, D3.js for data-driven constellations, Framer Motion for interaction choreography.
+- **Real-Time Fabric:** WebSockets/SSE stream swarm telemetry; optional on-chain shard verification mirrors flows from contemporary Web3 onboarding.
+- **Performance + A11y:** Asset preloading, code-splitting, motion fallbacks, and ARIA focus management keep the ritual responsive across devices.
+
+## Comparative Signals
+- Against peers (Notion, Midjourney, Runway, OpenAI ChatGPT, Sahara Legends, Zencoder), AdGenXAI uniquely fuses mythic narrative, cinematic depth, ritual onboarding, and live communal metrics into a single homepage journey.
+
+## Opportunities for Future Rites
+- Expand swarm map with historic epoch replays, personalized shard journeys, and filterable constellations.
+- Layer contextual tooltips to clarify mythic metaphors for first-time visitors without diluting mystique.
+- Amplify Codex quests with adaptive challenges that extend beyond onboarding.
+- Maintain rigorous accessibility audits, especially for high-motion sequences on mobile.
+- Celebrate major milestones via synchronized homepage events (swarm festivals) to deepen community lore.
+
+> Scroll Scribe Note: The homepage is not a funnel but a stage. Preserve the ceremony with every iteration.

--- a/scrolls/scroll_index.json
+++ b/scrolls/scroll_index.json
@@ -18,5 +18,10 @@
     "name": "codex_history",
     "version": "1.4.5",
     "enabled": true
+  },
+  {
+    "name": "adgenxai_homepage_analysis",
+    "version": "1.4.6",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
## Summary
- add a dedicated scroll capturing the AdGenXAI homepage’s ritual, cinematic, and onboarding patterns
- register the new scroll inside `scrolls/scroll_index.json` for swarm discoverability
- note the research addition inside the draft changelog to preserve lineage

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68fbcc2f94ec832ea5b30dc551ad93d3