### PR TITLE
Add PJ Ace-driven marketing surfaces for AdGenXAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Artifacts & Usability
 - Montage page with **Export .md/.json**.
 - Share buttons with **UTM** presets.
+- Marketing surface rebuilt around PJ Ace narrative: hero, feature highlights, Creator Showcase, case study templates, and product/developer landing pages aligned to AdGenXAI workflows.
 
 ### DevOps
 - `/api/health` instance/env guard.

--- a/pages/case-studies/[id].tsx
+++ b/pages/case-studies/[id].tsx
@@ -1,0 +1,44 @@
+import CaseStudyPage, { CaseStudyProps } from '@/components/marketing/CaseStudyPage';
+import { caseStudies } from '@/lib/content/pjAceContent';
+import { GetStaticPaths, GetStaticProps } from 'next';
+import Head from 'next/head';
+
+type CaseStudyRouteProps = {
+  caseStudy: CaseStudyProps;
+};
+
+export default function CaseStudyRoute({ caseStudy }: CaseStudyRouteProps) {
+  return (
+    <>
+      <Head>
+        <title>{caseStudy.title} — PJ Ace x AdGenXAI</title>
+        <meta name="description" content={`How PJ Ace shipped ${caseStudy.title} with AdGenXAI.`} />
+      </Head>
+      <main className="bg-slate-50 pb-24">
+        <CaseStudyPage {...caseStudy} />
+      </main>
+    </>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: Object.keys(caseStudies).map((id) => ({ params: { id } })),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps<CaseStudyRouteProps> = async ({ params }) => {
+  const id = params?.id as string;
+  const caseStudy = caseStudies[id];
+
+  if (!caseStudy) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      caseStudy,
+    },
+  };
+};

--- a/pages/creators/pj-ace.tsx
+++ b/pages/creators/pj-ace.tsx
@@ -1,0 +1,44 @@
+import CreatorProfile from '@/components/marketing/CreatorProfile';
+import Link from 'next/link';
+
+import { heroCopy, pjAceProfile } from '@/lib/content/pjAceContent';
+
+export default function PjAceCreatorPage() {
+  return (
+    <main className="space-y-20 bg-slate-50 pb-20">
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-amber-700 py-16 text-white">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 text-center">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Creator Showcase</p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">PJ Ace — AI Filmmaker & Viral Visionary</h1>
+          <p className="text-base text-slate-200">
+            {heroCopy.subhead}
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href={heroCopy.ctaPrimary.href}
+              className="inline-flex items-center justify-center rounded-full bg-amber-400 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-amber-300"
+            >
+              {heroCopy.ctaPrimary.text}
+            </Link>
+            <Link
+              href="/case-studies/im8-ad"
+              className="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white"
+            >
+              Explore IM8 case study
+            </Link>
+          </div>
+        </div>
+      </section>
+      <CreatorProfile {...pjAceProfile} />
+      <section className="mx-auto max-w-4xl space-y-6 rounded-3xl bg-white px-6 py-12 text-slate-700 shadow-xl">
+        <p className="text-xs uppercase tracking-[0.4em] text-amber-500">About PJ Ace</p>
+        <p className="text-lg leading-relaxed text-slate-700">
+          PJ Ace (PJ Accetturo) is a viral AI filmmaker who reimagines cinematic storytelling with generative AI. From meme-driven
+          ad campaigns to full 25-minute AI TV episodes, PJ combines cinematic craft with aggressive prompt engineering to generate
+          viral, platform-native content in days. His portfolio spans Veo 3, Midjourney Omni Reference, ElevenLabs voice cloning, and
+          Codex QA, proving how small teams can out-execute legacy studios with speed, humor, and platform-native design.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/pages/developers.tsx
+++ b/pages/developers.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+
+import { developerEndpoints, developerHero } from '@/lib/content/pjAceContent';
+
+const jobMetadata = [
+  { label: 'jobId', value: 'swarm_93ac-pjace-im8' },
+  { label: 'status', value: 'streaming' },
+  { label: 'sizeBytes', value: '48239410' },
+  { label: 'previewUrl', value: 'https://deploy-preview-128--adgenxai.netlify.app' },
+];
+
+export default function DevelopersPage() {
+  return (
+    <main className="space-y-24 bg-slate-50 pb-24 text-slate-900">
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-amber-700 py-20 text-white">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 text-center">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Developers</p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">{developerHero.title}</h1>
+          <p className="text-base text-slate-200">{developerHero.description}</p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href={developerHero.cta.href}
+              className="inline-flex items-center justify-center rounded-full bg-amber-400 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-amber-300"
+            >
+              {developerHero.cta.text}
+            </Link>
+            <Link
+              href="/templates/import?source=pj-ace-grandma"
+              className="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white"
+            >
+              Launch Grandma quickstart
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl space-y-10 px-6">
+        <header className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Quickstart</p>
+          <h2 className="text-3xl font-semibold text-slate-900">{developerHero.quickstartTitle}</h2>
+          <p className="text-sm text-slate-600">{developerHero.quickstartBody}</p>
+        </header>
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <pre className="overflow-auto rounded-2xl bg-slate-900 p-6 text-xs text-amber-200" aria-label="API request sample">
+            <code>{developerEndpoints[0]?.sample}</code>
+          </pre>
+          <div className="mt-6 rounded-2xl bg-slate-50 p-4 text-sm text-slate-600">
+            <p className="text-xs uppercase tracking-[0.3em] text-amber-500">CodexReplay metadata</p>
+            <dl className="mt-3 grid gap-2 md:grid-cols-2">
+              {jobMetadata.map((item) => (
+                <div key={item.label} className="flex items-center justify-between rounded-xl bg-white px-4 py-2">
+                  <dt className="font-semibold text-slate-900">{item.label}</dt>
+                  <dd className="text-xs text-slate-500">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl space-y-10 px-6">
+        <header className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Endpoints</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Wire up PJ Ace workflows programmatically</h2>
+        </header>
+        <div className="space-y-4">
+          {developerEndpoints.map((endpoint) => (
+            <div key={`${endpoint.method} ${endpoint.path}`} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-amber-500">
+                <span className="rounded-full bg-amber-100 px-3 py-1 text-amber-700">{endpoint.method}</span>
+                <span className="text-slate-600">{endpoint.path}</span>
+              </div>
+              <p className="mt-3 text-sm text-slate-600">{endpoint.description}</p>
+              {endpoint.sample ? (
+                <pre className="mt-4 overflow-auto rounded-2xl bg-slate-900 p-4 text-xs text-amber-200" aria-label="Endpoint sample">
+                  <code>{endpoint.sample}</code>
+                </pre>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl space-y-8 px-6">
+        <header className="space-y-2 text-center">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">CI/CD</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Codex review, Netlify preview, smoke tests</h2>
+        </header>
+        <div className="rounded-3xl bg-white p-8 shadow-xl">
+          <ol className="space-y-4 text-sm text-slate-600">
+            <li className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              Commit triggers GitHub Action → enqueue Codex review via <code className="rounded bg-slate-900 px-2 py-1 text-xs text-amber-200">POST /api/codex/review</code> → badge updates in StudioShare.
+            </li>
+            <li className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              Deploy preview minted at <code className="rounded bg-slate-900 px-2 py-1 text-xs text-amber-200">deploy-preview-*</code> → Puppeteer smoke + Lighthouse run streamed over SSE.
+            </li>
+            <li className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              Operators approve high-risk steps with provenance receipts stored in Supabase for replay overlays.
+            </li>
+          </ol>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,188 @@
+import Link from 'next/link';
+
+import {
+  analyticsHighlights,
+  deliverables,
+  featureHighlights,
+  heroCopy,
+  legalCta,
+  legalFeatures,
+  pjAceProfile,
+  rolloutPlan,
+  templateGallery,
+} from '@/lib/content/pjAceContent';
+
 export default function Home() {
   return (
-    <main style={{ padding: 24, fontFamily: 'system-ui' }}>
-      <h1>BeeHive online</h1>
-      <p>Static export + Netlify Functions are wired.</p>
-      <ul>
-        <li><a href="/.netlify/functions/ritual-badge">ritual-badge</a></li>
-        <li><a href="/.netlify/functions/ritual-ping">ritual-ping</a></li>
-        <li><a href="/.netlify/functions/ritual-metrics">ritual-metrics</a></li>
-      </ul>
+    <main className="space-y-24 bg-slate-50 pb-24 text-slate-900">
+      <section className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-amber-700 text-white">
+        <div className="mx-auto flex max-w-6xl flex-col gap-12 px-6 py-24">
+          <div className="space-y-8">
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-300">AI Filmmaker Studio</p>
+            <h1 className="text-5xl font-semibold sm:text-6xl">{heroCopy.headline}</h1>
+            <p className="max-w-3xl text-lg text-slate-200">{heroCopy.subhead}</p>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-300">{heroCopy.statLine}</p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href={heroCopy.ctaPrimary.href}
+                className="inline-flex items-center justify-center rounded-full bg-amber-400 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-amber-300"
+              >
+                {heroCopy.ctaPrimary.text}
+              </Link>
+              <Link
+                href={heroCopy.ctaSecondary.href}
+                className="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white"
+              >
+                {heroCopy.ctaSecondary.text}
+              </Link>
+            </div>
+          </div>
+          <div className="grid gap-6 md:grid-cols-3">
+            {featureHighlights.map((feature) => (
+              <div key={feature.title} className="rounded-3xl border border-white/20 bg-white/10 p-6 backdrop-blur">
+                <h3 className="text-xl font-semibold text-white">{feature.title}</h3>
+                <p className="mt-3 text-sm text-slate-200">{feature.description}</p>
+                {feature.stat ? <p className="mt-4 text-xs uppercase tracking-[0.2em] text-amber-200">{feature.stat}</p> : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-16 px-6">
+        <header className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-500">Creator Showcase</p>
+          <h2 className="text-4xl font-semibold text-slate-900">PJ Ace: Flagship AdGenXAI Filmmaker</h2>
+          <p className="max-w-3xl text-base text-slate-600">
+            PJ Ace shows the full stack — prompt templates, Veo 3 shotlists, ElevenLabs voice packs, and Codex QA sign-off. Study his
+            workflow, import the template, and launch a swarm in four clicks.
+          </p>
+        </header>
+        <div className="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+          <div className="space-y-6 rounded-3xl bg-white p-8 shadow-xl">
+            <h3 className="text-2xl font-semibold">Case studies</h3>
+            <ul className="space-y-4">
+              {pjAceProfile.projects.map((project) => (
+                <li key={project.id} className="flex flex-col gap-1 border-l-4 border-amber-300 pl-4">
+                  <div className="flex items-center justify-between text-sm text-slate-500">
+                    <span>{project.date}</span>
+                    <span>{project.views}</span>
+                  </div>
+                  <Link href={`/case-studies/${project.id}`} className="text-lg font-semibold text-slate-900 hover:text-amber-500">
+                    {project.title}
+                  </Link>
+                  <div className="flex flex-wrap gap-2 text-xs text-slate-500">
+                    {project.tags.map((tag) => (
+                      <span key={tag} className="rounded-full bg-slate-100 px-2 py-1 font-semibold uppercase tracking-wide">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <Link
+              href={pjAceProfile.ctaPrimary.href}
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+            >
+              {pjAceProfile.ctaPrimary.text}
+            </Link>
+          </div>
+          <div className="space-y-6 rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+            <h3 className="text-2xl font-semibold text-slate-900">Template gallery</h3>
+            <ul className="space-y-4">
+              {templateGallery.map((template) => (
+                <li key={template.name} className="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                  <span className="text-2xl" aria-hidden>
+                    {template.icon}
+                  </span>
+                  <div>
+                    <p className="text-lg font-semibold text-slate-900">{template.name}</p>
+                    <p className="text-sm text-slate-600">{template.description}</p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+            <Link href="/creators/pj-ace" className="text-sm font-semibold text-slate-900 hover:text-amber-500">
+              View PJ Ace profile →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6">
+        <div className="grid gap-10 rounded-3xl bg-white p-10 shadow-xl lg:grid-cols-2">
+          <div className="space-y-4">
+            <p className="text-xs uppercase tracking-[0.4em] text-amber-500">Compliance & Ethics</p>
+            <h2 className="text-3xl font-semibold text-slate-900">Keep likeness, voice, and provenance in-bounds</h2>
+            <p className="text-sm text-slate-600">
+              PJ Ace workflows rely on trusted approvals. AdGenXAI ships with consent capture, AI labels, and audit logs so you can move
+              fast without crossing lines.
+            </p>
+            <Link
+              href={legalCta.cta.href}
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+            >
+              {legalCta.cta.text}
+            </Link>
+          </div>
+          <ul className="space-y-3">
+            {legalFeatures.map((item) => (
+              <li key={item} className="flex items-start gap-3 rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
+                <span className="mt-1 inline-block h-2 w-2 rounded-full bg-amber-400" aria-hidden />
+                <p>{item}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-500">Analytics tuned for viral ops</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Measure PJ Ace-style momentum</h2>
+        </header>
+        <div className="grid gap-6 md:grid-cols-2">
+          {analyticsHighlights.map((item) => (
+            <div key={item.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-500">{item.title}</p>
+              <p className="mt-3 text-base text-slate-600">{item.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-500">Rollout</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Ship the AdGenXAI filmmaker experience</h2>
+        </header>
+        <ol className="space-y-3">
+          {rolloutPlan.map((item) => (
+            <li key={item} className="rounded-3xl border border-slate-200 bg-white p-5 text-sm text-slate-700 shadow-sm">
+              {item}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-8 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-500">Next Artifacts</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Pick the next deliverable</h2>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          {deliverables.map((item) => (
+            <div key={item.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-lg font-semibold text-slate-900">{item.title}</p>
+              <p className="mt-3 text-sm text-slate-600">{item.detail}</p>
+              <Link href="/studio-share" className="mt-4 inline-flex text-sm font-semibold text-slate-900 hover:text-amber-500">
+                Request artifact →
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/pages/product/ai-filmmaker-studio.tsx
+++ b/pages/product/ai-filmmaker-studio.tsx
@@ -1,0 +1,186 @@
+import Link from 'next/link';
+
+import { analyticsHighlights, featureHighlights, legalFeatures, templateGallery } from '@/lib/content/pjAceContent';
+
+const roster = [
+  { name: 'Ideation Agent', description: 'Drops trend-aware concepts seeded with PJ Ace prompt packs.' },
+  { name: 'Script Agent', description: 'Drafts scripts with meme beats and platform-native pacing.' },
+  { name: 'Shotlist Agent', description: 'Translates script into Veo 3-ready sequences and Omni references.' },
+  { name: 'Reference Manager', description: 'Stores Midjourney Omni Reference packs and continuity notes.' },
+  { name: 'Director Agent', description: 'Runs Veo 3, orchestrates ElevenLabs vocals, syncs final edit cues.' },
+  { name: 'Post-Production Agent', description: 'Stages Netlify previews, runs Lighthouse and Puppeteer tests.' },
+];
+
+const omniIntegrations = [
+  {
+    title: 'Omni Reference Upload',
+    detail: 'Drag and drop character look books, capture omniRef IDs, and keep styles consistent across shots.',
+  },
+  {
+    title: 'Veo 3 Shotlist Sync',
+    detail: 'Send structured shotlists to Veo 3 with camera moves, lighting notes, and voice cues.',
+  },
+  {
+    title: 'ElevenLabs Voice Chain',
+    detail: 'Request voice clones with consent receipts, monitor audio status, and drop into timeline automatically.',
+  },
+  {
+    title: 'Preview + QA Harness',
+    detail: 'Spin deploy previews, auto-run Puppeteer smoke, gather Codex QA notes directly in your swarm.',
+  },
+];
+
+export default function AiFilmmakerStudioPage() {
+  return (
+    <main className="space-y-24 bg-slate-50 pb-24 text-slate-900">
+      <section className="bg-gradient-to-br from-slate-900 via-slate-800 to-amber-700 py-20 text-white">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 text-center">
+          <p className="text-xs uppercase tracking-[0.4em] text-amber-300">Product</p>
+          <h1 className="text-4xl font-semibold sm:text-5xl">AI Filmmaker Studio</h1>
+          <p className="text-base text-slate-200">
+            Build PJ Ace-grade ad campaigns, meme drops, and long-form pilots with agent-first tooling, Veo 3 orchestration, and
+            Codex QA guardrails.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/templates/import?source=pj-ace-viral-ad"
+              className="inline-flex items-center justify-center rounded-full bg-amber-400 px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-amber-300"
+            >
+              Launch PJ Ace workflow
+            </Link>
+            <Link
+              href="/developers"
+              className="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white"
+            >
+              View API reference
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-8 px-6">
+        <header className="space-y-2 text-center">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Why AdGenXAI</p>
+          <h2 className="text-3xl font-semibold text-slate-900">PJ Ace&apos;s production line in a box</h2>
+          <p className="text-sm text-slate-600">
+            These features compress months of creative iteration into a few days, pairing agent-first orchestration with ethics-first
+            guardrails.
+          </p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          {featureHighlights.map((feature) => (
+            <div key={feature.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-lg font-semibold text-slate-900">{feature.title}</p>
+              <p className="mt-3 text-sm text-slate-600">{feature.description}</p>
+              {feature.stat ? <p className="mt-4 text-xs uppercase tracking-[0.2em] text-amber-500">{feature.stat}</p> : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-10 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Agent Swarm Studio</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Roster tuned for AI filmmaking</h2>
+          <p className="text-base text-slate-600">Use the same roster PJ Ace runs to take a prompt from spark to shipped.</p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-2">
+          {roster.map((agent) => (
+            <div key={agent.name} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-500">{agent.name}</p>
+              <p className="mt-3 text-sm text-slate-600">{agent.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto flex max-w-6xl flex-col gap-12 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Pipeline</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Integrations ready out of the box</h2>
+          <p className="text-base text-slate-600">Blend Veo 3, Midjourney Omni Reference, and ElevenLabs without leaving the swarm.</p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-2">
+          {omniIntegrations.map((item) => (
+            <div key={item.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <p className="text-lg font-semibold text-slate-900">{item.title}</p>
+              <p className="mt-2 text-sm text-slate-600">{item.detail}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-10 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Viral templates</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Start from PJ Ace playbooks</h2>
+        </header>
+        <div className="grid gap-6 md:grid-cols-3">
+          {templateGallery.map((template) => (
+            <div key={template.name} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <span className="text-3xl" aria-hidden>
+                {template.icon}
+              </span>
+              <p className="mt-4 text-lg font-semibold text-slate-900">{template.name}</p>
+              <p className="mt-2 text-sm text-slate-600">{template.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-10 px-6">
+        <header className="space-y-2">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">QA & Compliance</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Codex-reviewed before every launch</h2>
+        </header>
+        <div className="rounded-3xl bg-white p-8 shadow-xl">
+          <div className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+            <div className="space-y-4">
+              <p className="text-sm text-slate-600">
+                Every variant runs through Codex QA, Lighthouse, and Puppeteer before it leaves staging. Approvers receive structured
+                diffs, ethics flags, and provenance receipts to keep campaigns safe and fast.
+              </p>
+              <ul className="space-y-3">
+                {legalFeatures.map((feature) => (
+                  <li key={feature} className="flex items-start gap-3 rounded-2xl bg-slate-50 p-4 text-sm text-slate-700">
+                    <span className="mt-1 inline-block h-2 w-2 rounded-full bg-amber-400" aria-hidden />
+                    <p>{feature}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="space-y-4 rounded-3xl border border-slate-200 bg-slate-50 p-6">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-amber-500">Analytics Hooks</p>
+              <ul className="space-y-3">
+                {analyticsHighlights.slice(0, 3).map((metric) => (
+                  <li key={metric.title} className="rounded-2xl bg-white p-4 shadow-sm">
+                    <p className="text-sm font-semibold text-slate-900">{metric.title}</p>
+                    <p className="mt-2 text-xs text-slate-600">{metric.detail}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl space-y-8 px-6">
+        <header className="space-y-2 text-center">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-500">Ready when you are</p>
+          <h2 className="text-3xl font-semibold text-slate-900">Spin up a PJ Ace workflow in four clicks</h2>
+          <p className="text-sm text-slate-600">
+            Create campaign → Upload Omni references → Pick voice + distribution → Start swarm and watch variants stream in via SSE.
+          </p>
+        </header>
+        <div className="flex justify-center">
+          <Link
+            href="/templates/import?source=pj-ace-viral-ad"
+            className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+          >
+            Start now
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/marketing/CaseStudyPage.tsx
+++ b/src/components/marketing/CaseStudyPage.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link';
+
+export type CaseStudyProps = {
+  id: string;
+  title: string;
+  releaseDate: string;
+  metrics: { views: number; shares: number; costEstimate: string };
+  heroMedia: string;
+  tools: string[];
+  pipeline: Array<{ step: string; agent: string; snippet?: string }>;
+  shots: Array<{ scene: string; prompt: string; refImages?: string[] }>;
+  timeline: { days: number; phases: string[] };
+  ethicalNotes?: string;
+};
+
+export function CaseStudyPage({
+  title,
+  releaseDate,
+  metrics,
+  heroMedia,
+  tools,
+  pipeline,
+  shots,
+  timeline,
+  ethicalNotes,
+}: CaseStudyProps) {
+  return (
+    <article className="mx-auto flex max-w-5xl flex-col gap-12 px-6 py-16">
+      <header className="space-y-6">
+        <p className="text-sm uppercase tracking-[0.3em] text-slate-500">Case Study</p>
+        <h1 className="text-4xl font-semibold text-slate-900">{title}</h1>
+        <div className="flex flex-wrap gap-3 text-sm text-slate-500">
+          <span>{releaseDate}</span>
+          <span aria-hidden>•</span>
+          <span>{metrics.views.toLocaleString()} views</span>
+          <span aria-hidden>•</span>
+          <span>{metrics.shares.toLocaleString()} shares</span>
+          <span aria-hidden>•</span>
+          <span>Cost: {metrics.costEstimate}</span>
+        </div>
+        <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-black/80 p-6 text-white shadow-lg">
+          <p className="text-xs uppercase tracking-[0.3em] text-amber-300">Preview</p>
+          <p className="mt-2 text-lg font-semibold">{heroMedia}</p>
+          <p className="mt-2 text-sm text-slate-200">
+            This placeholder represents the Veo 3 cinematic reel that plays on the live site. Embed video via mux player once media
+            is cleared.
+          </p>
+        </div>
+      </header>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Tools & Pipeline</h2>
+        <div className="rounded-3xl border border-slate-200 p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-slate-800">Stack</h3>
+          <ul className="mt-3 flex flex-wrap gap-2 text-sm text-slate-600">
+            {tools.map((tool) => (
+              <li key={tool} className="rounded-full bg-slate-100 px-3 py-1 font-semibold">
+                {tool}
+              </li>
+            ))}
+          </ul>
+          <ol className="mt-6 space-y-3">
+            {pipeline.map((step) => (
+              <li key={`${step.step}-${step.agent}`} className="rounded-2xl bg-slate-50 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">{step.step}</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">{step.agent}</p>
+                {step.snippet ? (
+                  <pre className="mt-3 overflow-auto rounded-xl bg-slate-900 p-4 text-xs text-amber-200" aria-label="Prompt snippet">
+                    <code>{step.snippet}</code>
+                  </pre>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Shotlist & Prompt Library</h2>
+        <div className="space-y-4">
+          {shots.map((shot) => (
+            <div key={shot.scene} className="rounded-3xl border border-slate-200 p-6 shadow-sm">
+              <header className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-lg font-semibold text-slate-900">{shot.scene}</h3>
+                <button
+                  type="button"
+                  className="rounded-full border border-amber-400 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-500 transition hover:bg-amber-50"
+                >
+                  Copy prompt
+                </button>
+              </header>
+              <pre className="mt-4 overflow-auto rounded-xl bg-slate-50 p-4 text-sm text-slate-700" aria-label="Prompt">
+                <code>{shot.prompt}</code>
+              </pre>
+              {shot.refImages ? (
+                <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-500">
+                  {shot.refImages.map((img) => (
+                    <span key={img} className="rounded-full bg-slate-100 px-3 py-1 font-medium">
+                      {img}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Production Timeline</h2>
+        <div className="rounded-3xl border border-slate-200 p-6 shadow-sm">
+          <p className="text-sm font-medium text-slate-600">Total duration: {timeline.days} days</p>
+          <ul className="mt-3 grid gap-2 text-sm text-slate-600 md:grid-cols-2">
+            {timeline.phases.map((phase) => (
+              <li key={phase} className="rounded-xl bg-slate-50 px-4 py-3 font-semibold">
+                {phase}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Ethics & Provenance</h2>
+        <div className="rounded-3xl border border-amber-200 bg-amber-50/60 p-6 text-amber-900 shadow-sm">
+          <p className="text-sm leading-relaxed">
+            {ethicalNotes ??
+              'This production followed AdGenXAI consent flows for likeness usage, voice cloning disclosures, and AI-generated labelling.'}
+          </p>
+          <Link href="#audit-trail" className="mt-3 inline-flex text-sm font-semibold text-amber-700 hover:text-amber-500">
+            View audit trail →
+          </Link>
+        </div>
+      </section>
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold text-slate-900">Replicate this Workflow</h2>
+        <p className="text-sm text-slate-600">
+          Launch the PJ Ace template in AdGenXAI, complete with Veo 3 shotlists, ElevenLabs voice packs, and Codex QA guardrails.
+        </p>
+        <Link
+          href={`/templates/import?source=${encodeURIComponent(title)}`}
+          className="inline-flex max-w-xs items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+        >
+          Use this workflow
+        </Link>
+      </section>
+    </article>
+  );
+}
+
+export default CaseStudyPage;

--- a/src/components/marketing/CreatorProfile.tsx
+++ b/src/components/marketing/CreatorProfile.tsx
@@ -1,0 +1,133 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+export type CreatorProfileProps = {
+  name: string;
+  handle?: string;
+  heroImageUrl: string;
+  bio: string;
+  highlights: { label: string; value: string }[];
+  projects: Array<{
+    id: string;
+    title: string;
+    date: string;
+    thumbnail: string;
+    views: string;
+    tags: string[];
+  }>;
+  ctaPrimary: { text: string; href: string };
+};
+
+const highlightColors = ['bg-amber-100 text-amber-900', 'bg-teal-100 text-teal-900', 'bg-purple-100 text-purple-900'];
+
+export function CreatorProfile({
+  name,
+  handle,
+  heroImageUrl,
+  bio,
+  highlights,
+  projects,
+  ctaPrimary,
+}: CreatorProfileProps) {
+  const [hoveredProject, setHoveredProject] = useState<string | null>(null);
+
+  const sortedProjects = useMemo(() => {
+    return [...projects].sort((a, b) => a.title.localeCompare(b.title));
+  }, [projects]);
+
+  return (
+    <section className="mx-auto grid max-w-6xl gap-12 px-6 py-16 lg:grid-cols-[360px_1fr]">
+      <div className="space-y-6">
+        <div className="relative overflow-hidden rounded-3xl border border-slate-200 shadow-lg">
+          <Image
+            src={heroImageUrl}
+            alt={`${name} hero`}
+            width={720}
+            height={900}
+            className="h-full w-full object-cover"
+            unoptimized
+          />
+        </div>
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-900">{name}</h1>
+          {handle ? (
+            <p className="mt-1 text-slate-500">@{handle}</p>
+          ) : null}
+          <p className="mt-4 text-lg leading-relaxed text-slate-700">{bio}</p>
+        </div>
+        <dl className="grid gap-3">
+          {highlights.map((item, index) => (
+            <div
+              key={item.label}
+              className={`flex items-center justify-between rounded-2xl px-4 py-3 text-sm font-semibold ${highlightColors[index % highlightColors.length]}`}
+            >
+              <dt>{item.label}</dt>
+              <dd>{item.value}</dd>
+            </div>
+          ))}
+        </dl>
+        <Link
+          href={ctaPrimary.href}
+          className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+        >
+          {ctaPrimary.text}
+        </Link>
+      </div>
+      <div className="space-y-10">
+        <header className="space-y-2">
+          <p className="text-sm uppercase tracking-[0.2em] text-slate-500">Creator Showcase</p>
+          <h2 className="text-4xl font-semibold text-slate-900">Featured Projects</h2>
+          <p className="text-base text-slate-600">
+            Click into any project to study the workflow, prompt engineering, and distribution strategy that powers PJ Ace&apos;s
+            viral output. Hover previews reveal quick GIF loops pulled from Veo 3 cinematic takes.
+          </p>
+        </header>
+        <div className="grid gap-6 md:grid-cols-2">
+          {sortedProjects.map((project) => (
+            <article
+              key={project.id}
+              onMouseEnter={() => setHoveredProject(project.id)}
+              onMouseLeave={() => setHoveredProject((current) => (current === project.id ? null : current))}
+              className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+            >
+              <div className="relative h-48 w-full overflow-hidden">
+                <Image
+                  src={project.thumbnail}
+                  alt={`${project.title} thumbnail`}
+                  fill
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  className={`object-cover transition duration-300 ${hoveredProject === project.id ? 'scale-105' : ''}`}
+                  unoptimized
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-2 p-6">
+                <header className="space-y-1">
+                  <h3 className="text-xl font-semibold text-slate-900">{project.title}</h3>
+                  <p className="text-sm text-slate-500">{project.date}</p>
+                </header>
+                <p className="text-sm font-medium text-slate-700">{project.views}</p>
+                <div className="mt-auto flex flex-wrap gap-2">
+                  {project.tags.map((tag) => (
+                    <span key={tag} className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+                <Link
+                  href={`/case-studies/${project.id}`}
+                  className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900 transition hover:text-amber-500"
+                >
+                  See workflow
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CreatorProfile;

--- a/src/lib/content/pjAceContent.ts
+++ b/src/lib/content/pjAceContent.ts
@@ -1,0 +1,367 @@
+import { CaseStudyProps } from '@/components/marketing/CaseStudyPage';
+import { CreatorProfileProps } from '@/components/marketing/CreatorProfile';
+
+type FeatureCard = {
+  title: string;
+  description: string;
+  stat?: string;
+};
+
+type TemplateItem = {
+  name: string;
+  description: string;
+  icon: string;
+};
+
+type ApiEndpoint = {
+  method: string;
+  path: string;
+  description: string;
+  sample?: string;
+};
+
+export const pjAceProfile: CreatorProfileProps = {
+  name: 'PJ Ace',
+  handle: 'pjaccetturo',
+  heroImageUrl: 'https://images.unsplash.com/photo-1522199996308-ccdcb5b06222?auto=format&fit=crop&w=800&q=80',
+  bio: 'PJ Ace (PJ Accetturo) is a viral AI filmmaker who reimagines cinematic storytelling with generative AI. From meme-driven ad campaigns to full 25-minute AI TV episodes, PJ combines cinematic craft with aggressive prompt engineering to generate viral, platform-native content in days.',
+  highlights: [
+    { label: 'Viral reach', value: '120M views in 48 hours' },
+    { label: 'Production speed', value: 'Campaigns in < 3 days' },
+    { label: 'Cost delta', value: '$500 vs $500K legacy' },
+  ],
+  projects: [
+    {
+      id: 'im8-ad',
+      title: 'IM8 Digital Twin Ad',
+      date: '2024',
+      thumbnail: 'https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?auto=format&fit=crop&w=640&q=80',
+      views: '120M views • 2 days',
+      tags: ['Veo 3', 'ElevenLabs', 'Omni Reference'],
+    },
+    {
+      id: 'grandma-video',
+      title: 'Grandma Forgot Her Clothes',
+      date: '2023',
+      thumbnail: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=640&q=80',
+      views: '48M views • 72 hours',
+      tags: ['Comedy', 'Prompt Lab'],
+    },
+    {
+      id: 'ai-tv',
+      title: 'AI TV Episode',
+      date: '2024',
+      thumbnail: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=640&q=80',
+      views: 'Series pilot in 6 days',
+      tags: ['Long-form', 'Codex QA'],
+    },
+    {
+      id: 'popeyes',
+      title: 'Popeyes Meme Sprint',
+      date: '2023',
+      thumbnail: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=640&q=80',
+      views: '17M views • 48 hours',
+      tags: ['Brand Beef', 'Rapid Iteration'],
+    },
+  ],
+  ctaPrimary: {
+    text: 'Launch PJ Ace Template',
+    href: '/templates/import?source=pj-ace-viral-ad',
+  },
+};
+
+export const caseStudies: Record<string, CaseStudyProps> = {
+  'im8-ad': {
+    id: 'im8-ad',
+    title: 'IM8 Digital Twin Ad',
+    releaseDate: 'February 2024',
+    metrics: { views: 120_000_000, shares: 890_000, costEstimate: '$12K estimated' },
+    heroMedia: 'Veo 3 sequence: Beckham digital twin walking through neon IM8 store set',
+    tools: ['Veo 3', 'Midjourney Omni Reference', 'ElevenLabs', 'Codex QA', 'Final Cut Pro'],
+    pipeline: [
+      {
+        step: 'Ideate',
+        agent: 'Agent Swarm Studio — Meme Strategist',
+        snippet: 'Objective: Remind fans IM8 can body-double Beckham. Hook: \'David Beckham clones himself for sneaker drop\'.',
+      },
+      {
+        step: 'Generate',
+        agent: 'Veo 3 Shot Director',
+        snippet: 'camera: dolly forward, lighting: neon blue + amber rim; prompt: Beckham digital twin emerges from portal.',
+      },
+      {
+        step: 'Voice',
+        agent: 'ElevenLabs Voice Forge',
+        snippet: '{ "voice": "beckham-clone", "consentId": "signed-2024-02-01", "style": "confident" }',
+      },
+      {
+        step: 'QA',
+        agent: 'Codex Review Bot',
+        snippet: 'Check pacing < 30s, ensure likeness consent attached, prep Netlify preview + Lighthouse run.',
+      },
+    ],
+    shots: [
+      {
+        scene: 'Portal reveal',
+        prompt: 'Ultra wide establishing shot of neon IM8 flagship, Beckham digital twin stepping through portal, cinematic neon bloom.',
+        refImages: ['omniRef:beckham-front', 'omniRef:beckham-profile'],
+      },
+      {
+        scene: 'Times Square broadcast',
+        prompt: 'Times Square billboards synchronizing to IM8 logo as digital twin sprints across rooftops.',
+      },
+      {
+        scene: 'Locker room close-up',
+        prompt: 'Close-up of IM8 sneaker rotating in zero gravity, Beckham twin narrates benefits.',
+      },
+    ],
+    timeline: { days: 2, phases: ['Prompt lab & approvals', 'Veo 3 generation + Omni referencing', 'Edit, QA, distribution sprint'] },
+    ethicalNotes: 'Celebrity likeness cleared via IM8 talent agreement; ElevenLabs consent recorded and watermarking enabled. Final export labelled as AI-generated and archived with provenance JSON.',
+  },
+  'grandma-video': {
+    id: 'grandma-video',
+    title: 'Grandma Forgot Her Clothes',
+    releaseDate: 'August 2023',
+    metrics: { views: 48_000_000, shares: 310_000, costEstimate: '$3K estimated' },
+    heroMedia: 'Viral TikTok-ready cut featuring grandma protagonist and alpaca cameo',
+    tools: ['Veo 3', 'ChatGPT Prompt Lab', 'After Effects', 'Codex QA'],
+    pipeline: [
+      {
+        step: 'Spark',
+        agent: 'Ideation Agent',
+        snippet: 'Premise: Grandma forgets clothes, alpaca saves the day. Ensure comedic beats hit at 3s, 7s, 12s.',
+      },
+      {
+        step: 'Storyboard',
+        agent: 'Shotlist Agent',
+        snippet: 'Generate 6-shot vertical storyboard optimized for TikTok loops; include alt endings for A/B tests.',
+      },
+      {
+        step: 'Generate',
+        agent: 'Veo 3 Rapid Render',
+        snippet: 'Prompt pack with slapstick cues, pastel lighting, comedic timing markers.',
+      },
+      {
+        step: 'Distribution',
+        agent: 'Launch Director',
+        snippet: 'Schedule TikTok+IG cross-post, attach meme seeding kit for Discord communities.',
+      },
+    ],
+    shots: [
+      {
+        scene: 'Kitchen chaos',
+        prompt: 'Grandma in apron realizes outfit missing, alpaca bursts through door tossing sequined robe.',
+      },
+      {
+        scene: 'Community reaction',
+        prompt: 'Split-screen of TikTok duets laughing, comments flying, grandma waves from neon stage.',
+      },
+    ],
+    timeline: { days: 3, phases: ['Prompt lab', 'Rapid Veo 3 renders', 'Social seeding + meme remix'] },
+    ethicalNotes: 'All performers synthetic; comedic scenario flagged safe-for-work. Automatic AI-generated label displayed on upload.',
+  },
+  'ai-tv': {
+    id: 'ai-tv',
+    title: 'AI TV Episode',
+    releaseDate: 'May 2024',
+    metrics: { views: 3_200_000, shares: 210_000, costEstimate: '$25K estimated' },
+    heroMedia: '25-minute AI-native TV pilot exploring multiverse heists',
+    tools: ['Veo 3', 'Midjourney Omni Reference', 'ElevenLabs', 'DaVinci Resolve', 'Codex QA'],
+    pipeline: [
+      {
+        step: 'Writers room',
+        agent: 'Script Agent',
+        snippet: 'Generate 4-act structure, maintain PJ Ace tone (earnest + absurdist).',
+      },
+      {
+        step: 'Look dev',
+        agent: 'Reference Manager',
+        snippet: 'Upload Omni reference pack to lock character continuity across 25 minutes.',
+      },
+      {
+        step: 'Production',
+        agent: 'Director Agent',
+        snippet: 'Batch Veo 3 sequences, orchestrate ElevenLabs ensemble, auto-sync subtitles.',
+      },
+      {
+        step: 'QA + Release',
+        agent: 'Codex QA',
+        snippet: 'Full Codex review with notes on pacing, compliance, and metadata export for streaming partners.',
+      },
+    ],
+    shots: [
+      {
+        scene: 'Heist briefing',
+        prompt: 'Diverse cast at holographic table planning multiverse jump, cinematic lighting, kinetic camera.',
+        refImages: ['omniRef:crew-front', 'omniRef:hologram'],
+      },
+      {
+        scene: 'Portal chase',
+        prompt: 'Extended chase through shifting universes, match-on-action transitions, saturated color palette.',
+      },
+    ],
+    timeline: { days: 6, phases: ['Act structure + voice casting', 'Look dev + Veo 3 batches', 'Edit + QC + distribution'] },
+    ethicalNotes: 'Voice actors compensated and licensed for ElevenLabs clones; distribution includes AI-disclosure bumpers and accessible subtitles.',
+  },
+};
+
+export const heroCopy = {
+  headline: 'AdGenXAI powers the next generation of AI filmmakers.',
+  subhead:
+    'Creators like PJ Ace use agent-first pipelines to turn a prompt into a viral cinematic ad or a 25-minute AI TV episode in days, not months.',
+  ctaPrimary: { text: 'Spin up PJ Ace workflow', href: '/templates/import?source=pj-ace-viral-ad' },
+  ctaSecondary: { text: 'Explore Creator Showcase', href: '/creators/pj-ace' },
+  statLine: 'Idea → Agent Swarm → Veo 3 → Post-edit → Preview & test → Deploy & iterate.',
+};
+
+export const featureHighlights: FeatureCard[] = [
+  {
+    title: 'Agent Swarm Studio',
+    description:
+      'Orchestrate ideation, script, shotlist, and post-production agents in one roster UI. Codex QA watches every revision before launch.',
+    stat: 'Template roster: PJ Ace Meme Strategist, Scriptwright, Shotlist Pilot, Director, Post Supervisor.',
+  },
+  {
+    title: 'Viral Templates',
+    description:
+      'Start with PJ Ace battle-tested templates — Bible Vlog, Diss Track Ads, Brand Beef, Documentary-style epic. Import prompts, shotlists, and distribution plans instantly.',
+  },
+  {
+    title: 'Legal & Ethics Guardrails',
+    description:
+      'Consent flows for likeness and voice, AI-generated labels, provenance audit trail, and moderation checks keep high-velocity teams compliant.',
+  },
+];
+
+export const legalFeatures = [
+  'Likeness consent modal captures signatures before render.',
+  'Voice cloning disclosure layered into ElevenLabs flows.',
+  'Auto-labels apply “AI-generated” watermark plus provenance JSON.',
+  'Moderation queue catches banned phrases and high-risk prompts.',
+  'Downloadable audit trail with prompts, models, approvals, and timestamps.',
+  'Copyright & provenance panel educates brands on model licenses.',
+];
+
+export const analyticsHighlights = [
+  {
+    title: 'Viral Momentum',
+    detail: 'Track velocity of views in the first 24 hours vs baseline to steer spend in real-time.',
+  },
+  {
+    title: 'Prompt ROI',
+    detail: 'Tie conversion lift to specific prompts and variants so creative ops double down on what works.',
+  },
+  {
+    title: 'Variant “meme-ability”',
+    detail: 'Composite share, comment, and completion data to crown the clip that travels the internet.',
+  },
+  {
+    title: 'Badge usage',
+    detail: 'Monitor how often operators escalate high-risk tasks for manual approval.',
+  },
+  {
+    title: 'Echo reuse',
+    detail: 'See which prompts and reference packs become cross-campaign staples.',
+  },
+];
+
+export const templateGallery: TemplateItem[] = [
+  {
+    name: 'Bible Vlog',
+    description: 'Weekly serialized short tackling sacred stories with PJ Ace’s cinematic meme language.',
+    icon: '📖',
+  },
+  {
+    name: 'Brand Beef',
+    description: 'Spin up playful call-outs and clapbacks overnight with Veo 3, Omni Reference, and TikTok-native pacing.',
+    icon: '🔥',
+  },
+  {
+    name: 'Documentary Epic',
+    description: 'ElevenLabs-narrated hero journey with Omni reference-driven consistency and Codex QA gating.',
+    icon: '🎬',
+  },
+];
+
+export const developerEndpoints: ApiEndpoint[] = [
+  {
+    method: 'POST',
+    path: '/api/agents/run',
+    description: 'Launch a swarm using PJ Ace templates with async job tokens and SSE updates.',
+    sample: `curl -X POST https://adgenxai.dev/api/agents/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "templateId": "pj-ace-viral-ad",
+    "campaign": {
+      "name": "IM8 Blitz",
+      "objective": "Launch digital twin ad",
+      "assets": []
+    },
+    "variants": 3
+  }'`,
+  },
+  {
+    method: 'POST',
+    path: '/api/pipeline/veo3/generate',
+    description: 'Server-side Veo 3 orchestration with shotlists and Omni Reference IDs.',
+  },
+  {
+    method: 'POST',
+    path: '/api/reference/upload',
+    description: 'Store Omni reference packs and return IDs for pipeline hydration.',
+  },
+  {
+    method: 'POST',
+    path: '/api/audio/elevenlabs',
+    description: 'Trigger voice generation with consent payload and fetch signed audio URLs.',
+  },
+  {
+    method: 'POST',
+    path: '/api/codex/review',
+    description: 'Submit preview diffs for Codex QA review before approvals.',
+  },
+  {
+    method: 'GET',
+    path: '/live/:agentId/stream',
+    description: 'Subscribe to SSE stream for live swarm updates, artifact status, and preview URLs.',
+  },
+];
+
+export const rolloutPlan = [
+  'Week 0 — Design hero, Creator Showcase, Case Study, and demo flows with PJ Ace narrative.',
+  'Week 1 — Build marketing hero, feature cards, CreatorProfile, and CaseStudy components with mock data + template CTA.',
+  'Week 2 — Wire preview sandbox to mocked async jobs and SSE streams, add Codex review stub.',
+  'Week 3 — Connect Netlify previews, enable /api/agents/run to enqueue jobs, layer privacy + consent flows.',
+  'Week 4 — Ship analytics dashboard, legal hub, and exportable case study prompt packs.',
+];
+
+export const deliverables = [
+  {
+    title: 'Starter Next.js page',
+    detail: 'Hero, feature cards, Creator Showcase, and demo sandbox wired to mocked endpoints.',
+  },
+  {
+    title: 'Case Study template & 3 filled pages',
+    detail: 'Grandma Video, IM8 Ad, and AI TV Show rendered with downloadable prompt packs.',
+  },
+  {
+    title: 'Creator Showcase UI spec',
+    detail: 'Component props, states, accessibility notes, and PJ Ace project JSON for designers.',
+  },
+];
+
+export const legalCta = {
+  headline: 'AI ethics, provenance, and consent front-and-center.',
+  body: 'Surface likeness approval workflows, voice cloning disclosures, AI-generated labels, and downloadable audit trails to keep brand campaigns compliant without slowing them down.',
+  cta: { text: 'Review compliance playbook', href: '/legal/ai-consent' },
+};
+
+export const developerHero = {
+  title: 'Build with AdGenXAI APIs',
+  description: 'SSE streams, async job tokens, and Codex-reviewed pipelines help developers replicate PJ Ace-grade workflows in their stacks.',
+  cta: { text: 'View API reference', href: '/developers#api' },
+  quickstartTitle: 'Quickstart: Replicate the Grandma video pipeline',
+  quickstartBody:
+    'Use the `/api/agents/run` endpoint with the `pj-ace-grandma` template to orchestrate ideation, Veo 3 renders, and Codex QA from one request.',
+};
+


### PR DESCRIPTION
## Summary
- replace the marketing homepage with PJ Ace narrative content, feature highlights, rollout plan, and CTA templates
- add Creator Showcase, case study template routes, and AI Filmmaker Studio page powered by reusable content modules
- expand developer landing page with API hooks, CodexReplay metadata, and workflow quickstarts referencing PJ Ace pipelines

## Testing
- not run (project has no package manifest or scripts to execute)


------
https://chatgpt.com/codex/tasks/task_b_68fbcabc8090832eac35283d3a1a7885